### PR TITLE
Mark remaining failing tests to `xfail`

### DIFF
--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -230,7 +230,12 @@ class TestDtype(base.BaseDtypeTests):
 
 
 class TestGroupBy(base.BaseGroupbyTests):
-    pass
+    @pytest.mark.xfail(
+        pd.__version__ < "3.1.0",
+        reason="Test fails on pandas below 3.1.0, see pandas GH #64111",
+    )
+    def test_groupby_agg_extension(self, data_for_grouping):
+        return super().test_groupby_agg_extension(data_for_grouping)
 
 
 class TestGetitem(base.BaseGetitemTests):
@@ -403,6 +408,25 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
+    test_compare_scalar_mark_xfail = pytest.mark.xfail(
+        pd.__version__ < "3.1.0",
+        reason="Test fails on pandas below 3.1.0, see pandas GH #64365",
+    )
+
+    @pytest.mark.parametrize(
+        "comparison_op",
+        [
+            operator.eq,
+            operator.ne,
+            pytest.param(operator.le, marks=test_compare_scalar_mark_xfail),
+            pytest.param(operator.lt, marks=test_compare_scalar_mark_xfail),
+            pytest.param(operator.ge, marks=test_compare_scalar_mark_xfail),
+            pytest.param(operator.gt, marks=test_compare_scalar_mark_xfail),
+        ],
+    )
+    def test_compare_scalar(self, data, comparison_op):
+        return super().test_compare_scalar(data, comparison_op)
+
     def test_comparable_units(self):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         s2 = pd.Series([1, 2, 3], dtype="unit[km]")
@@ -531,6 +555,10 @@ class TestVarious(BaseExtensionTests):
         expected = pd.Series([u.Quantity("1 m"), u.Quantity("1 m/s")], dtype=object)
         tm.assert_series_equal(expected, concatenated)
 
+    @pytest.mark.xfail(
+        pd.__version__ < "3.1.0",
+        reason="Test fails on pandas below 3.1.0, see pandas GH #62523",
+    )
     def test_add_new_value_with_different_unit(self):
         s1 = pd.Series(["1 m"], dtype="unit")
         s1.at[1] = u.Quantity("1 ft")

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -237,6 +237,12 @@ class TestGroupBy(base.BaseGroupbyTests):
     def test_groupby_agg_extension(self, data_for_grouping):
         return super().test_groupby_agg_extension(data_for_grouping)
 
+    @pytest.mark.xfail(
+        reason="The UnitsDtype is non of the dtypes for which the test expects a successful grouping, therefore no TypeError is raised",
+    )
+    def test_in_numeric_groupby(self, data_for_grouping):
+        return super().test_in_numeric_groupby(data_for_grouping)
+
 
 class TestGetitem(base.BaseGetitemTests):
     def test_unitless(self):
@@ -348,6 +354,12 @@ class TestSetitem(base.BaseSetitemTests):
     def test_readonly_propagates_to_numpy_array_method(self, data):
         super().test_readonly_propagates_to_numpy_array_method(data)
 
+    @pytest.mark.xfail(
+        reason="Index.get_loc() returns a InvalidIndexError instead of the expected KeyError (key not in index for setter) because Quantity is an instance of abc.Iterable"
+    )
+    def test_loc_setitem_with_expansion_preserves_ea_index_dtype(self, data):
+        super().test_loc_setitem_with_expansion_preserves_ea_index_dtype(data)
+
 
 class TestParsing(base.BaseParsingTests):
     @pytest.mark.parametrize("generic", [False, True])
@@ -408,7 +420,7 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
-    test_compare_scalar_mark_xfail = pytest.mark.xfail(
+    compare_scalar_mark_xfail: pytest.MarkDecorator = pytest.mark.xfail(
         pd.__version__ < "3.1.0",
         reason="Test fails on pandas below 3.1.0, see pandas GH #64365",
     )
@@ -418,10 +430,10 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         [
             operator.eq,
             operator.ne,
-            pytest.param(operator.le, marks=test_compare_scalar_mark_xfail),
-            pytest.param(operator.lt, marks=test_compare_scalar_mark_xfail),
-            pytest.param(operator.ge, marks=test_compare_scalar_mark_xfail),
-            pytest.param(operator.gt, marks=test_compare_scalar_mark_xfail),
+            pytest.param(operator.le, marks=compare_scalar_mark_xfail),
+            pytest.param(operator.lt, marks=compare_scalar_mark_xfail),
+            pytest.param(operator.ge, marks=compare_scalar_mark_xfail),
+            pytest.param(operator.gt, marks=compare_scalar_mark_xfail),
         ],
     )
     def test_compare_scalar(self, data, comparison_op):


### PR DESCRIPTION
Add `xfail` marks to all remaining failing tests, test-suite should be fully green now.

The following tests fail on the current pandas version, but have been fixed in upcoming pandas `3.1.0` version. Therefore the `xfail` mark is conditionally to only set the mark on `pd.__version__ < "3.1.0"` and a reference to the PR fixing the issue is stated in the `reason` tag:
* `TestGroupBy::test_groupby_agg_extension`
* `TestComparisonOps::test_compare_scalar`: Mark only for `le`, `lt`, `ge`, and `gt`
* `TestVarious::test_add_new_value_with_different_unit`

The following two tests are just failing at the moment, see the `reason` tag for an explanation:
* `TestGroupBy::test_in_numeric_groupby`: Requires also pandas `3.1.0` for the grouping, but fails due to `UnitsDtype` not in the `dtypes` expected to succeed.
* `TestSetitem::test_loc_setitem_with_expansion_preserves_ea_index_dtype`