### PR TITLE
Refactor binary operations

### DIFF
--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -579,6 +579,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         def _binop(self, other):
             if isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame)):
+                # rely on pandas to unbox and dispatch to us
                 return NotImplemented
 
             self_q: u.Quantity = as_quantity(self)
@@ -678,6 +679,10 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             normalize, sort, ascending, bins, dropna
         )
 
+UnitsExtensionArray._add_arithmetic_ops()
+UnitsExtensionArray._add_comparison_ops()
+UnitsExtensionArray.__pow__ = UnitsExtensionArray._create_method(operator.pow)
+
 
 @register_series_accessor("units")
 class UnitsSeriesAccessor:
@@ -756,7 +761,4 @@ class UnitsDataFrameAccessor:
         return self.obj.apply(_f)
 
 
-UnitsExtensionArray._add_arithmetic_ops()
-UnitsExtensionArray._add_comparison_ops()
 
-UnitsExtensionArray.__pow__ = UnitsExtensionArray._create_method(operator.pow)

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 import astropy.units as u
 import numpy as np
 import pandas as pd
+from astropy.units import UnitConversionError
 from pandas.api.extensions import (
     ExtensionArray,
     ExtensionDtype,
@@ -573,71 +574,41 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return np.isnan(self.value)
 
     @classmethod
-    def _create_method(cls, op, coerce_to_dtype=True, result_dtype=None):
-        # Overridden from the default variant to by-pass conversion to numpy arrays.
+    def _create_arithmetic_method(cls, op):
+        op_name = f"__{op.__name__}__"
 
-        # Get info about the operator
-        op_name: str = getattr(op, "__name__", str(op))
-        is_comparison: bool = op_name in [
-            "__eq__",
-            "__ge__",
-            "__gt__",
-            "__le__",
-            "__lt__",
-            "__ne__",
-            "eq",
-            "ge",
-            "gt",
-            "le",
-            "lt",
-            "ne",
-        ]
-        is_equality: bool = op_name in ["eq", "ne", "__eq__", "__ne__"]
-        is_divmod: bool = op_name in ["divmod", "__divmod__", "rdivmod", "__rdivmod__"]
-
-        def _invalid_operator():
-            if is_equality:
+        def _binop(self, other):
+            if isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame)):
                 return NotImplemented
-            else:
-                raise TypeError
+
+            self_q: u.Quantity = as_quantity(self)
+            try:
+                other_q = as_quantity(other)
+                result_q = op(self_q, other_q)
+            except (TypeError, UnitConversionError):
+                result_q = op(self_q, other)
+
+            if op_name in ["__divmod__", "__rdivmod__"]:
+                return cls(result_q[0]), cls(result_q[1])
+            return cls(result_q)
+
+        return set_function_name(_binop, op_name, cls)
+
+    @classmethod
+    def _create_comparison_method(cls, op):
+        op_name = f"__{op.__name__}__"
 
         def _binop(self, other):
             if isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame)):
                 # rely on pandas to unbox and dispatch to us
                 return NotImplemented
 
-            elif is_scalar(other):
-                if is_comparison:
-                    return NotImplemented
-
-            elif is_array_like(other):
-                if not isinstance(other.dtype, UnitsDtype):
-                    if is_comparison:
-                        return _invalid_operator()
-
             # Convert the thing to quantities
             self_q: u.Quantity = as_quantity(self)
             other_q: u.Quantity = as_quantity(other)
-
-            if is_comparison:
-                # Try apply conversion (we need same type for comparisons)
-                if is_array_like(other) and other.dtype != self.dtype:
-                    try:
-                        other_q = convert(other_q, self.unit)
-                    except InvalidUnitConversion:
-                        return _invalid_operator()
-
-            result_q = op(self_q, other_q)
-
-            # Divmod returns tuple of two Quantity objects and they have to be handled separately
-            if is_divmod:
-                if coerce_to_dtype:
-                    return cls(result_q[0]), cls(result_q[1])
-                return result_q[0], result_q[1]
-            else:
-                if coerce_to_dtype:
-                    return cls(result_q)
-                return result_q
+            if other_q.unit != self_q.unit:
+                other_q = convert(other_q, self_q.unit)
+            return op(self_q, other_q)
 
         return set_function_name(_binop, op_name, cls)
 

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -590,6 +590,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 result_q = op(self_q, other)
 
             if op_name in ["__divmod__", "__rdivmod__"]:
+                # divmod returns a tuple of results
                 return cls(result_q[0]), cls(result_q[1])
             return cls(result_q)
 
@@ -679,6 +680,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             normalize, sort, ascending, bins, dropna
         )
 
+
 UnitsExtensionArray._add_arithmetic_ops()
 UnitsExtensionArray._add_comparison_ops()
 UnitsExtensionArray.__pow__ = UnitsExtensionArray._create_method(operator.pow)
@@ -759,6 +761,3 @@ class UnitsDataFrameAccessor:
                 return col
 
         return self.obj.apply(_f)
-
-
-

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -605,6 +605,14 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
             # Convert the thing to quantities
             self_q: u.Quantity = as_quantity(self)
+
+            if op_name in ["__eq__", "__ne__"]:
+                try:
+                    other_q: u.Quantity = as_quantity(other)
+                    return op(self_q, other_q)
+                except TypeError:
+                    return op(self_q, other)
+
             other_q: u.Quantity = as_quantity(other)
             if other_q.unit != self_q.unit:
                 other_q = convert(other_q, self_q.unit)

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -618,6 +618,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 try:
                     other_q: u.Quantity = as_quantity(other)
                     if other_q.unit != self_q.unit:
+                        # This enables comparison of temperature values
                         other_q = convert(other_q, self_q.unit)
                     return op(self_q, other_q)
                 except (TypeError, InvalidUnitConversion):
@@ -626,6 +627,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
             other_q: u.Quantity = as_quantity(other)
             if other_q.unit != self_q.unit:
+                # This enables comparison of temperature values
                 other_q = convert(other_q, self_q.unit)
             return op(self_q, other_q)
 

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 import astropy.units as u
 import numpy as np
 import pandas as pd
-from astropy.units import UnitConversionError
 from pandas.api.extensions import (
     ExtensionArray,
     ExtensionDtype,
@@ -592,15 +591,13 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 # rely on pandas to unbox and dispatch to us
                 return NotImplemented
 
-            self_q: u.Quantity = as_quantity(self)
-            try:
-                other_q = as_quantity(other)
-                result_q = op(self_q, other_q)
-            except (TypeError, UnitConversionError):
-                result_q = op(self_q, other)
             # For multiplication and division other can also be a unit
             if is_multiplication and isinstance(other, UnitInstance):
                 other = u.Quantity(1, other)
+
+            self_q = as_quantity(self)
+            other_q = as_quantity(other)
+            result_q = op(self_q, other_q)
 
             if is_divmod:
                 # divmod returns a tuple of results
@@ -626,11 +623,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                     other_q: u.Quantity = as_quantity(other)
                     return op(self_q, other_q)
                 except TypeError:
+                    # Compare things that cannot be converted to quantity, using astropy logic
                     return op(self_q, other)
 
             other_q: u.Quantity = as_quantity(other)
             if other_q.unit != self_q.unit:
-                other_q = convert(other_q, self_q._unit)
+                other_q = convert(other_q, self_q.unit)
             return op(self_q, other_q)
 
         return set_function_name(_binop, op_name, cls)

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -211,7 +211,9 @@ def as_quantity(
     if isinstance(obj, u.Quantity):
         return u.Quantity(obj, copy=copy)
     elif isinstance(obj, UnitsExtensionArray):
-        return u.Quantity(obj.value, obj.unit, copy=copy)
+        return u.Quantity(obj._value, obj._unit, copy=copy)
+    elif isinstance(obj, ABCSeries) and isinstance(obj.dtype, UnitsDtype):
+        return as_quantity(obj.array, copy=copy)
     elif is_array_like(obj) and obj.dtype == "timedelta64[ns]":
         # Note: Timedelta is internally represented as int64
         return u.Quantity(np.asarray(obj, dtype=np.int64), "ns", copy=copy).to("s")
@@ -286,12 +288,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         self._value: np.ndarray[np.float64] = q.value.astype(float)
 
     @property
-    def value(self) -> np.ndarray:
-        """The numerical values (without unit)."""
-        return self._value
-
-    @property
-    def unit(self) -> UnitInstance:
+    def _unit(self) -> UnitInstance:
         """The unit itself."""
         return self.dtype.unit
 
@@ -300,7 +297,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self._dtype
 
     def __len__(self) -> int:
-        return len(self.value)
+        return len(self._value)
 
     def __array__(
         self, dtype: DtypeObj = object, copy: bool | None = None
@@ -330,9 +327,9 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             # Converting self first to a Quantity and then to a ndarray requires a copy, so copy flag will be set to True
             copy = True
         elif dtype:
-            arr = self.value.astype(dtype, copy=copy)
+            arr = self._value.astype(dtype, copy=copy)
         else:
-            arr = np.asarray(self.value, copy=copy)
+            arr = np.asarray(self._value, copy=copy)
 
         # Set writable flag depending on self._readonly and only when no copy was made
         if self._readonly and copy is not True:
@@ -362,14 +359,14 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             # Check that the physical type of the unit of the nan Quantity is the same as that of UnitsExtensionArray.
             # Here we are a bit flexible so `np.nan * u.cm` is considered to be the same as `np.nan * u.m` as the value
             # of the Quantity and therefore the scaling of the unit does not really matter for nan.
-            if item.unit.physical_type == self.unit.physical_type:
-                return np.isnan(self.value).any()
+            if item.unit.physical_type == self._unit.physical_type:
+                return np.isnan(self._value).any()
             return False
         return (item == self).any()  # type: ignore[union-attr]
 
     @property
     def nbytes(self) -> int:
-        return self.value.nbytes + sys.getsizeof(self.unit)
+        return self._value.nbytes + sys.getsizeof(self._unit)
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy=False) -> UnitsExtensionArray:
@@ -432,7 +429,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
     def unique(self) -> UnitsExtensionArray:
         """Unique values."""
-        return self.__class__(pd.unique(self.value), unit=self.unit)
+        return self.__class__(pd.unique(self._value), unit=self._unit)
 
     def searchsorted(
         self,
@@ -474,7 +471,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             str_values: list[str] = [str(q) for q in self.to_quantity()]
             return pd.Series(str_values, dtype=dtype).array
         elif dtype in ["O", "object", object]:
-            return np.array([x * self.unit for x in self.value], dtype=object)
+            return np.array([x * self._unit for x in self._value], dtype=object)
         elif isinstance(dtype, str):
             try:
                 dtype = UnitsDtype(dtype)
@@ -493,7 +490,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             raise NotImplementedError(dtype)
         result = UnitsExtensionArray.__new__(UnitsExtensionArray)
         result._dtype = self.dtype
-        result._value = self.value
+        result._value = self._value
         result._readonly = self._readonly
         return result
 
@@ -502,18 +499,18 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         TODO: Not sure if this is the best (differ on boxed?)
         """
-        return lambda x: str(x) if isinstance(x, u.Quantity) else f"{x} {self.unit}"
+        return lambda x: str(x) if isinstance(x, u.Quantity) else f"{x} {self._unit}"
 
     def __getitem__(self, item) -> u.Quantity | UnitsExtensionArray:
         # Return zerodim Quantity object for singular item
         if is_scalar(item):
-            return u.Quantity(self.value[item], unit=self.unit)
+            return u.Quantity(self._value[item], unit=self._unit)
 
         # Use pandas utility function to check and convert the item to a valid indexer
         item = check_array_indexer(self, item)
 
         # Create new UnitsExtensionArray
-        result: UnitsExtensionArray = self._simple_new(self.value[item], self.dtype)
+        result: UnitsExtensionArray = self._simple_new(self._value[item], self.dtype)
 
         # If the result is a view, keep read-only flag
         if getitem_returns_view(self, item):
@@ -534,17 +531,17 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         # Convert NaN to Quantity with correct unit
         if is_scalar(value) and np.isnan(value):
-            value = u.Quantity(value, self.unit)
+            value = u.Quantity(value, self._unit)
 
         # Use pandas utility function to check and convert the item to a valid indexer
         key = check_array_indexer(self, key)
 
         # Convert value to quantity and convert to same unit as self if necessary
         q: u.Quantity = as_quantity(value)
-        q: u.Quantity = convert(q, self.unit)
+        q: u.Quantity = convert(q, self._unit)
 
         # Set the values at the given key to the numerical values of the quantity
-        self.value[key] = q.value
+        self._value[key] = q.value
 
     def take(self, indices, allow_fill=False, fill_value=None) -> UnitsExtensionArray:
         """Integer-based selection of items."""
@@ -553,8 +550,10 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 fill_value = np.nan
             else:
                 fill_value = fill_value.value
-        values = take(self.value, indices, allow_fill=allow_fill, fill_value=fill_value)
-        return UnitsExtensionArray(values, self.unit)
+        values = take(
+            self._value, indices, allow_fill=allow_fill, fill_value=fill_value
+        )
+        return UnitsExtensionArray(values, self._unit)
 
     @classmethod
     def _concat_same_type(cls, to_concat) -> UnitsExtensionArray:
@@ -562,20 +561,34 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             return cls([])
         elif len(to_concat) == 1:
             return to_concat[0]
-        elif len(set(item.unit for item in to_concat)) != 1:
+        elif len(set(item._unit for item in to_concat)) != 1:
             # TODO: And this actually never happens.
             raise ValueError("Not all concatenated arrays have the same units.")
         else:
             return cls(
-                np.concatenate([item.value for item in to_concat]), to_concat[0].unit
+                np.concatenate([item._value for item in to_concat]), to_concat[0]._unit
             )
 
     def isna(self):
-        return np.isnan(self.value)
+        return np.isnan(self._value)
 
     @classmethod
     def _create_arithmetic_method(cls, op):
         op_name = f"__{op.__name__}__"
+        is_multiplication: bool = op_name in [
+            "__mul__",
+            "__rmul__",
+            "__truediv__",
+            "__rtruediv__",
+            "mul",
+            "rmul",
+            "truediv",
+            "rtruediv",
+        ]
+        is_divmod = op_name in ["__divmod__", "__rdivmod__", "divmod", "rdivmod"]
+
+        if op_name == "divmod":
+            raise ValueError("Jdi do prdele")
 
         def _binop(self, other):
             if isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame)):
@@ -588,8 +601,11 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 result_q = op(self_q, other_q)
             except (TypeError, UnitConversionError):
                 result_q = op(self_q, other)
+            # For multiplication and division other can also be a unit
+            if is_multiplication and isinstance(other, UnitInstance):
+                other = u.Quantity(1, other)
 
-            if op_name in ["__divmod__", "__rdivmod__"]:
+            if is_divmod:
                 # divmod returns a tuple of results
                 return cls(result_q[0]), cls(result_q[1])
             return cls(result_q)
@@ -617,13 +633,13 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
             other_q: u.Quantity = as_quantity(other)
             if other_q.unit != self_q.unit:
-                other_q = convert(other_q, self_q.unit)
+                other_q = convert(other_q, self_q._unit)
             return op(self_q, other_q)
 
         return set_function_name(_binop, op_name, cls)
 
     def copy(self, deep=False) -> UnitsExtensionArray:
-        return self.__class__(self.value, self.unit, copy=True)
+        return self.__class__(self._value, self._unit, copy=True)
 
     def _reduce(
         self, name: str, skipna: bool = True, keepdims: bool = False, **kwargs
@@ -649,10 +665,10 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             result: u.Quantity = getattr(q, name)(**kwargs)
 
         elif name in to_nanops:
-            data = self.value
+            data = self._value
             method = getattr(nanops, "nan" + name)
             result_without_dim = method(data, skipna=skipna)
-            result = u.Quantity(result_without_dim, self.unit)
+            result = u.Quantity(result_without_dim, self._unit)
 
         elif name in to_error:
             raise TypeError(f"Cannot perform '{name}' with type '{self.dtype}'")
@@ -666,7 +682,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
     def _values_for_factorize(self) -> tuple[np.ndarray, Any]:
         """Generate values for factorization"""
-        return self.value, None
+        return self._value, None
 
     @classmethod
     def _from_factorized(cls, values, original) -> UnitsExtensionArray:
@@ -676,7 +692,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
     ) -> pd.Series:
         # TODO: Is it possible to include units? We'd need custom index
-        return pd.Index(self.value).value_counts(
+        return pd.Index(self._value).value_counts(
             normalize, sort, ascending, bins, dropna
         )
 
@@ -699,7 +715,7 @@ class UnitsSeriesAccessor:
     @property
     def unit(self) -> UnitInstance:
         """The Series' unit."""
-        return self.obj.array.unit
+        return self.obj.array._unit
 
     def _wrap(self, result: UnitsExtensionArray) -> pd.Series:
         """Construct a series with different data but same index and name."""

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -587,9 +587,6 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         ]
         is_divmod = op_name in ["__divmod__", "__rdivmod__", "divmod", "rdivmod"]
 
-        if op_name == "divmod":
-            raise ValueError("Jdi do prdele")
-
         def _binop(self, other):
             if isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame)):
                 # rely on pandas to unbox and dispatch to us

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -694,7 +694,9 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
 UnitsExtensionArray._add_arithmetic_ops()
 UnitsExtensionArray._add_comparison_ops()
-UnitsExtensionArray.__pow__ = UnitsExtensionArray._create_method(operator.pow)
+UnitsExtensionArray.__pow__ = UnitsExtensionArray._create_arithmetic_method(
+    operator.pow
+)
 
 
 @register_series_accessor("units")

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -617,8 +617,10 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             if op_name in ["__eq__", "__ne__"]:
                 try:
                     other_q: u.Quantity = as_quantity(other)
+                    if other_q.unit != self_q.unit:
+                        other_q = convert(other_q, self_q.unit)
                     return op(self_q, other_q)
-                except TypeError:
+                except (TypeError, InvalidUnitConversion):
                     # Compare things that cannot be converted to quantity, using astropy logic
                     return op(self_q, other)
 

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -579,12 +579,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             "__rmul__",
             "__truediv__",
             "__rtruediv__",
-            "mul",
-            "rmul",
-            "truediv",
-            "rtruediv",
         ]
-        is_divmod = op_name in ["__divmod__", "__rdivmod__", "divmod", "rdivmod"]
+        is_divmod = op_name in ["__divmod__", "__rdivmod__"]
 
         def _binop(self, other):
             if isinstance(other, (ABCIndex, ABCSeries, ABCDataFrame)):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -520,7 +520,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             pytest.param(1, pd.Series([False, False]), id="number"),
             pytest.param("1 m", pd.Series([True, False]), id="string-as-unit"),
             pytest.param("m", pd.Series([False, False]), id="string"),
-            pytest.param(1 * u.m, pd.Series([True, False]), id="unit"),
+            pytest.param(1 * u.m, pd.Series([True, False]), id="quantity"),
             pytest.param(pd.Series([1, 2]), pd.Series([False, False]), id="series"),
             pytest.param(
                 pd.Series([100, 50], dtype="unit[cm]"),

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -447,8 +447,6 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "comparison_op",
         [
-            pytest.param(operator.eq, marks=compare_scalar_mark_xfail),
-            pytest.param(operator.ne, marks=compare_scalar_mark_xfail),
             pytest.param(operator.le, marks=compare_scalar_mark_xfail),
             pytest.param(operator.lt, marks=compare_scalar_mark_xfail),
             pytest.param(operator.ge, marks=compare_scalar_mark_xfail),
@@ -480,8 +478,6 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "op",
         [
-            operator.eq,
-            operator.ne,
             operator.le,
             operator.lt,
             operator.ge,
@@ -505,8 +501,6 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "op",
         [
-            operator.eq,
-            operator.ne,
             operator.le,
             operator.lt,
             operator.ge,
@@ -519,6 +513,37 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             op(s1, other)
         with pytest.raises(InvalidUnitConversion):
             op(other, s1)
+
+    @pytest.mark.parametrize(
+        ("other", "result"),
+        [
+            pytest.param(1, pd.Series([False, False]), id="number"),
+            pytest.param("1 m", pd.Series([True, False]), id="string-as-unit"),
+            pytest.param("m", pd.Series([False, False]), id="string"),
+            pytest.param(1 * u.m, pd.Series([True, False]), id="unit"),
+            pytest.param(pd.Series([1, 2]), pd.Series([False, False]), id="series"),
+            pytest.param(
+                pd.Series([100, 200], dtype="unit[cm]"),
+                pd.Series([True, True]),
+                id="series",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "op",
+        [
+            operator.eq,
+            operator.ne,
+        ],
+    )
+    def test_eq_ne(self, other, result, op):
+        s = pd.Series([1, 2], dtype="unit[m]")
+        if op == operator.eq:
+            expected = result
+        else:
+            expected = ~result
+        result = op(s, other)
+        tm.assert_series_equal(result, expected)
 
 
 class TestRepr:

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -429,13 +429,10 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
 
     @pytest.mark.xfail(reason="Will be resolved in a future PR.")
     def test_radd(self):
+        # TODO: Add tests for other r-ops when fix is finished
         result = (5 * u.cm) + pd.Series([1, 2, 3], dtype="unit[m]")
         expected = pd.Series([105, 205, 305], dtype="unit[cm]")
         tm.assert_series_equal(result, expected)
-
-    #@pytest.mark.xfail(reason="Makes no sense for pandas-provided fixtures")
-    #def test_divmod_series_array(self, data, data_for_twos):
-    #    super().test_divmod_series_array(data, data_for_twos)
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -672,8 +672,6 @@ class TestVarious(BaseExtensionTests):
         expected = UnitsExtensionArray([1, np.nan], unit="m")
         assert unique._unit == expected._unit
         np.testing.assert_equal(expected._value, unique._value)
-        assert unique._unit == expected._unit
-        np.testing.assert_equal(expected._value, unique._value)
 
     @pytest.mark.parametrize(
         ("obj", "expected"),

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -452,15 +452,25 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         tm.assert_series_equal(result, expected)
 
 
-class TestComparisonOps(base.BaseComparisonOpsTests):
-    compare_scalar_mark_xfail: pytest.MarkDecorator = pytest.mark.xfail(
-        pd.__version__ < "3.1.0",
-        reason="Test fails on pandas below 3.1.0, see pandas GH #64365",
-    )
+compare_scalar_mark_xfail: pytest.MarkDecorator = pytest.mark.xfail(
+    pd.__version__ < "3.1.0",
+    reason="Test fails on pandas below 3.1.0, see pandas GH #64365",
+)
 
-    @compare_scalar_mark_xfail
-    def test_compare_scalar(self, data, ordering_comparison_op):
-        return super().test_compare_scalar(data, ordering_comparison_op)
+
+class TestComparisonOps(base.BaseComparisonOpsTests):
+    @pytest.mark.parametrize(
+        "op",
+        [
+            *_all_equality_comparison_operators,
+            *[
+                pytest.param(op, marks=compare_scalar_mark_xfail)
+                for op in _all_ordering_comparison_operators
+            ],
+        ],
+    )
+    def test_compare_scalar(self, data, op):
+        return super().test_compare_scalar(data, op)
 
     def test_comparable_units(self):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -523,9 +523,14 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             pytest.param(1 * u.m, pd.Series([True, False]), id="unit"),
             pytest.param(pd.Series([1, 2]), pd.Series([False, False]), id="series"),
             pytest.param(
-                pd.Series([100, 200], dtype="unit[cm]"),
-                pd.Series([True, True]),
-                id="series",
+                pd.Series([100, 50], dtype="unit[cm]"),
+                pd.Series([True, False]),
+                id="series-with-compatible-unit",
+            ),
+            pytest.param(
+                pd.Series([1, 2], dtype="unit[kg]"),
+                pd.Series([False, False]),
+                id="series-with-incompatible-unit",
             ),
         ],
     )

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -46,6 +46,30 @@ _all_arithmetic_operators: list[str] = [
     "__mod__",
     "__rmod__",
 ]
+_all_equality_comparison_operators = [operator.eq, operator.ne]
+_all_ordering_comparison_operators = [
+    operator.le,
+    operator.lt,
+    operator.ge,
+    operator.gt,
+]
+
+
+@pytest.fixture(
+    params=_all_equality_comparison_operators + _all_ordering_comparison_operators
+)
+def comparison_op(request):
+    return request.param
+
+
+@pytest.fixture(params=_all_equality_comparison_operators)
+def equality_comparison_op(request):
+    return request.param
+
+
+@pytest.fixture(params=_all_ordering_comparison_operators)
+def ordering_comparison_op(request):
+    return request.param
 
 
 @pytest.fixture(params=_all_arithmetic_operators)
@@ -166,20 +190,6 @@ _all_numeric_reductions = ["sum", "max", "min", "mean", "std", "var", "median"]
 @pytest.fixture
 def sort_by_key():
     return None
-
-
-@pytest.fixture(
-    params=[
-        operator.eq,
-        operator.ne,
-        operator.le,
-        operator.lt,
-        operator.ge,
-        operator.gt,
-    ]
-)
-def comparison_op(request):
-    return request.param
 
 
 @pytest.fixture(params=_all_numeric_reductions)
@@ -448,17 +458,9 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         reason="Test fails on pandas below 3.1.0, see pandas GH #64365",
     )
 
-    @pytest.mark.parametrize(
-        "comparison_op",
-        [
-            pytest.param(operator.le, marks=compare_scalar_mark_xfail),
-            pytest.param(operator.lt, marks=compare_scalar_mark_xfail),
-            pytest.param(operator.ge, marks=compare_scalar_mark_xfail),
-            pytest.param(operator.gt, marks=compare_scalar_mark_xfail),
-        ],
-    )
-    def test_compare_scalar(self, data, comparison_op):
-        return super().test_compare_scalar(data, comparison_op)
+    @compare_scalar_mark_xfail
+    def test_compare_scalar(self, data, ordering_comparison_op):
+        return super().test_compare_scalar(data, ordering_comparison_op)
 
     def test_comparable_units(self):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
@@ -479,21 +481,12 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         expected = pd.Series([False, True, False])
         tm.assert_series_equal(expected, result)
 
-    @pytest.mark.parametrize(
-        "op",
-        [
-            operator.le,
-            operator.lt,
-            operator.ge,
-            operator.gt,
-        ],
-    )
-    def test_incomparable_units(self, op):
+    def test_incomparable_units(self, ordering_comparison_op):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         s2 = pd.Series([1000, 2000, 3000], dtype="unit[s]")
 
         with pytest.raises(InvalidUnitConversion):
-            op(s1, s2)
+            ordering_comparison_op(s1, s2)
 
     @pytest.mark.parametrize(
         "other",
@@ -502,21 +495,12 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             pytest.param(pd.Series([1, 2, 3]), id="series"),
         ],
     )
-    @pytest.mark.parametrize(
-        "op",
-        [
-            operator.le,
-            operator.lt,
-            operator.ge,
-            operator.gt,
-        ],
-    )
-    def test_with_incompatible_non_units(self, op, other):
+    def test_with_incompatible_non_units(self, ordering_comparison_op, other):
         s = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         with pytest.raises(InvalidUnitConversion):
-            op(s, other)
+            ordering_comparison_op(s, other)
         with pytest.raises(InvalidUnitConversion):
-            op(other, s)
+            ordering_comparison_op(other, s)
 
     @pytest.mark.parametrize(
         ("other", "result"),
@@ -538,20 +522,13 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             ),
         ],
     )
-    @pytest.mark.parametrize(
-        "op",
-        [
-            operator.eq,
-            operator.ne,
-        ],
-    )
-    def test_eq_ne(self, other, result, op):
+    def test_eq_ne(self, other, result, equality_comparison_op):
         s = pd.Series([1, 2], dtype="unit[m]")
-        if op == operator.eq:
+        if equality_comparison_op == operator.eq:
             expected = result
         else:
             expected = ~result
-        result = op(s, other)
+        result = equality_comparison_op(s, other)
         tm.assert_series_equal(result, expected)
 
 

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -473,12 +473,31 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         expected = pd.Series([False, True, False])
         tm.assert_series_equal(expected, result)
 
-    def test_temperature_comparison(self):
-        s1 = pd.Series([0, -10, 10], dtype="unit[deg_C]")
-        s2 = pd.Series([270, 270, 270], dtype="unit[K]")
+    @pytest.mark.parametrize(
+        "other",
+        [
+            pytest.param(pd.Series([270, 270, 270], dtype="unit[K]"), id="series"),
+            pytest.param(270 * u.K, id="value"),
+        ],
+    )
+    def test_temperature_inequality(self, other):
+        s = pd.Series([0, -10, 10], dtype="unit[deg_C]")
 
-        result = s1 < s2
+        result = s < other
         expected = pd.Series([False, True, False])
+        tm.assert_series_equal(expected, result)
+
+    @pytest.mark.parametrize(
+        "other",
+        [
+            pytest.param(pd.Series([273.15, 274, 0], dtype="unit[K]"), id="series"),
+            pytest.param(32 * u.imperial.deg_F, id="value"),
+        ],
+    )
+    def test_temperature_equality(self, other):
+        s = pd.Series([0, -10, 10], dtype="unit[deg_C]")
+        result = s == other
+        expected = pd.Series([True, False, False])
         tm.assert_series_equal(expected, result)
 
     def test_incomparable_units(self, ordering_comparison_op):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -489,7 +489,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         s2 = pd.Series([1000, 2000, 3000], dtype="unit[s]")
 
         with pytest.raises(InvalidUnitConversion):
-            _ = op(s1, s2)
+            op(s1, s2)
 
     @pytest.mark.parametrize(
         "other",

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -26,6 +26,7 @@ from pandas_units_extension.units import (
     UnitsDtype,
     UnitsExtensionArray,
     UnitsSeriesAccessor,
+    InvalidUnitConversion,
 )
 
 _all_arithmetic_operators: list[str] = [
@@ -426,6 +427,15 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         self._check_divmod_op(ser, divmod, ser[0])
         self._check_divmod_op(ser[0], ops.rdivmod, ser)
 
+    def test_radd(self):
+        result = (5 * u.cm) + pd.Series([1, 2, 3], dtype="unit[m]")
+        expected = pd.Series([105, 205, 305], dtype="unit[cm]")
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.xfail(reason="Makes no sense for pandas-provided fixtures")
+    def test_divmod_series_array(self, data, data_for_twos):
+        super().test_divmod_series_array(data, data_for_twos)
+
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
     compare_scalar_mark_xfail: pytest.MarkDecorator = pytest.mark.xfail(
@@ -436,8 +446,8 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "comparison_op",
         [
-            operator.eq,
-            operator.ne,
+            pytest.param(operator.eq, marks=compare_scalar_mark_xfail),
+            pytest.param(operator.ne, marks=compare_scalar_mark_xfail),
             pytest.param(operator.le, marks=compare_scalar_mark_xfail),
             pytest.param(operator.lt, marks=compare_scalar_mark_xfail),
             pytest.param(operator.ge, marks=compare_scalar_mark_xfail),
@@ -470,10 +480,33 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         s2 = pd.Series([1000, 2000, 3000], dtype="unit[s]")
 
-        assert all(s1 != s2)
+        with pytest.raises(InvalidUnitConversion):
+            _ = s1 < s2
 
-        with pytest.raises(TypeError):
-            s1 < s2
+    @pytest.mark.parametrize(
+        "other",
+        [
+            pytest.param(1, id="number"),
+            pytest.param(pd.Series([1, 2, 3]), id="series"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "op",
+        [
+            operator.eq,
+            operator.ne,
+            operator.le,
+            operator.lt,
+            operator.ge,
+            operator.gt,
+        ],
+    )
+    def test_with_incompatible(self, op, other):
+        s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
+        with pytest.raises(InvalidUnitConversion):
+            op(s1, other)
+        with pytest.raises(InvalidUnitConversion):
+            op(other, s1)
 
 
 class TestRepr:

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -476,12 +476,23 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         expected = pd.Series([False, True, False])
         tm.assert_series_equal(expected, result)
 
-    def test_incomparable_units(self):
+    @pytest.mark.parametrize(
+        "op",
+        [
+            operator.eq,
+            operator.ne,
+            operator.le,
+            operator.lt,
+            operator.ge,
+            operator.gt,
+        ],
+    )
+    def test_incomparable_units(self, op):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         s2 = pd.Series([1000, 2000, 3000], dtype="unit[s]")
 
         with pytest.raises(InvalidUnitConversion):
-            _ = s1 < s2
+            _ = op(s1, s2)
 
     @pytest.mark.parametrize(
         "other",
@@ -501,7 +512,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             operator.gt,
         ],
     )
-    def test_with_incompatible(self, op, other):
+    def test_with_incompatible_non_units(self, op, other):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         with pytest.raises(InvalidUnitConversion):
             op(s1, other)

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -676,6 +676,8 @@ class TestVarious(BaseExtensionTests):
         expected = UnitsExtensionArray([1, np.nan], unit="m")
         assert unique._unit == expected._unit
         np.testing.assert_equal(expected._value, unique._value)
+        assert unique._unit == expected._unit
+        np.testing.assert_equal(expected._value, unique._value)
 
     @pytest.mark.parametrize(
         ("obj", "expected"),
@@ -710,7 +712,7 @@ class TestVarious(BaseExtensionTests):
     )
     @pytest.mark.parametrize("copy", [True, False])
     def test_as_quantity(self, obj, expected, copy):
-        # Convert the obj annd check that the result is as expected
+        # Convert the obj and check that the result is as expected
         result: u.Quantity = as_quantity(obj, copy=copy)
         np.testing.assert_equal(result, expected)
 

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -427,6 +427,7 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         self._check_divmod_op(ser, divmod, ser[0])
         self._check_divmod_op(ser[0], ops.rdivmod, ser)
 
+    @pytest.mark.xfail(reason="Will be resolved in a future PR.")
     def test_radd(self):
         result = (5 * u.cm) + pd.Series([1, 2, 3], dtype="unit[m]")
         expected = pd.Series([105, 205, 305], dtype="unit[cm]")

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -433,9 +433,9 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         expected = pd.Series([105, 205, 305], dtype="unit[cm]")
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.xfail(reason="Makes no sense for pandas-provided fixtures")
-    def test_divmod_series_array(self, data, data_for_twos):
-        super().test_divmod_series_array(data, data_for_twos)
+    #@pytest.mark.xfail(reason="Makes no sense for pandas-provided fixtures")
+    #def test_divmod_series_array(self, data, data_for_twos):
+    #    super().test_divmod_series_array(data, data_for_twos)
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):
@@ -508,11 +508,11 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         ],
     )
     def test_with_incompatible_non_units(self, op, other):
-        s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
+        s = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         with pytest.raises(InvalidUnitConversion):
-            op(s1, other)
+            op(s, other)
         with pytest.raises(InvalidUnitConversion):
-            op(other, s1)
+            op(other, s)
 
     @pytest.mark.parametrize(
         ("other", "result"),


### PR DESCRIPTION
Note: I change the comparison logic so that unit-compatibility is always required, even for == and !=. It was confusing imho.