### PR TITLE
ENH/TST: Multiply and Division with unit and allow Series in `as_quantity`

### DIFF
--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -211,6 +211,8 @@ def as_quantity(
         return u.Quantity(obj, copy=copy)
     elif isinstance(obj, UnitsExtensionArray):
         return u.Quantity(obj._value, obj._unit, copy=copy)
+    elif isinstance(obj, ABCSeries) and isinstance(obj.dtype, UnitsDtype):
+        return as_quantity(obj.array, copy=copy)
     elif is_array_like(obj) and obj.dtype == "timedelta64[ns]":
         # Note: Timedelta is internally represented as int64
         return u.Quantity(np.asarray(obj, dtype=np.int64), "ns", copy=copy).to("s")

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -591,6 +591,16 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         ]
         is_equality: bool = op_name in ["eq", "ne", "__eq__", "__ne__"]
         is_divmod: bool = op_name in ["divmod", "__divmod__", "rdivmod", "__rdivmod__"]
+        is_multiplication: bool = op_name in [
+            "__mul__",
+            "__rmul__",
+            "__truediv__",
+            "__rtruediv__",
+            "mul",
+            "rmul",
+            "truediv",
+            "rtruediv",
+        ]
 
         def _invalid_operator():
             if is_equality:
@@ -611,6 +621,10 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 if not isinstance(other.dtype, UnitsDtype):
                     if is_comparison:
                         return _invalid_operator()
+
+            # For multiplication and division other can also be a unit
+            if is_multiplication and isinstance(other, UnitInstance):
+                other = u.Quantity(1, other)
 
             # Convert the thing to quantities
             self_q: u.Quantity = as_quantity(self)

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
-from pandas.core import ops
+from pandas.core import ops, roperator
 from pandas.tests.extension import base
 from pandas.tests.extension.base import BaseOpsUtil
 from pandas.tests.extension.base.base import BaseExtensionTests
@@ -429,6 +429,15 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         ser = pd.Series(data)
         self._check_divmod_op(ser, divmod, ser[0])
         self._check_divmod_op(ser[0], ops.rdivmod, ser)
+
+    @pytest.mark.parametrize(
+        "op", [operator.mul, roperator.rmul, operator.truediv, roperator.rtruediv]
+    )
+    def test_mul_div_with_unit(self, data, op):
+        s = pd.Series(data)
+        result: pd.Series = op(s, u.m)
+        expected = pd.Series(op(data.to_quantity(), u.m), dtype="unit")
+        tm.assert_series_equal(result, expected)
 
 
 class TestComparisonOps(base.BaseComparisonOpsTests):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -26,6 +26,7 @@ from pandas_units_extension.units import (
     UnitsDtype,
     UnitsExtensionArray,
     UnitsSeriesAccessor,
+    as_quantity,
 )
 
 _all_arithmetic_operators: list[str] = [
@@ -610,3 +611,45 @@ class TestVarious(BaseExtensionTests):
         expected = UnitsExtensionArray([1, np.nan], unit="m")
         assert unique._unit == expected._unit
         np.testing.assert_equal(expected._value, unique._value)
+
+    @pytest.mark.parametrize(
+        ("obj", "expected"),
+        [
+            pytest.param(1 * u.m, u.Quantity(1, u.m), id="Quantity"),
+            pytest.param(
+                UnitsExtensionArray([1, 2] * u.m),
+                u.Quantity([1, 2], u.m),
+                id="UnitsExtensionArray",
+            ),
+            pytest.param(
+                pd.Series([1, 2], dtype="unit[m]"), u.Quantity([1, 2], u.m), id="Series"
+            ),
+            pytest.param(
+                pd.Series([1e9, 2e9], dtype="timedelta64[ns]"),
+                u.Quantity([1, 2], u.s),
+                id="Timedelta Series",
+            ),
+            pytest.param([], u.Quantity([], ""), id="Empty List"),
+            pytest.param(
+                ["1 m", "2 m"], u.Quantity([1, 2], u.m), id="List of Strings with Units"
+            ),
+            pytest.param(
+                [1 * u.m, 2 * u.m], u.Quantity([1, 2], u.m), id="List of Quantities"
+            ),
+            pytest.param(
+                np.array([1 * u.m, 2 * u.m], dtype=object),
+                u.Quantity([1, 2], u.m),
+                id="Numpy Array of Quantities",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("copy", [True, False])
+    def test_as_quantity(self, obj, expected, copy):
+        # Convert the obj annd check that the result is as expected
+        result: u.Quantity = as_quantity(obj, copy=copy)
+        np.testing.assert_equal(result, expected)
+
+        # Check that always a copy is made when copy=True
+        # We do not check the other case as a copy cannot always be prevented
+        if copy:
+            assert np.may_share_memory(result, expected) is False


### PR DESCRIPTION
This PR adds the possibility to multiply or divide a Series/`UnitsExtensionArray` with a astropy unit and thereby closes #23. On the occasion I also added the possibility to use a Series in `as_quantity`, as this function is publicly exposed this seems like a good alternative to the way through the `SeriesUnitsAccessor` with `Series.units.to_quantity()`. Currently this accepts only Series with `UnitsDtype`, this could be extended to all numeric dtypes, but not sure if that is useful.

I also added tests for both the multiplication/division and various inputs to `as_quantity`.