### PR TITLE
Address A.I. comments

### DIFF
--- a/pandas_units_extension/__init__.py
+++ b/pandas_units_extension/__init__.py
@@ -26,9 +26,6 @@ __all__ = [
     "UnitsDataFrameAccessor",
     "Unit",
     "__version__",
-    "__url__",
-    "__author__",
-    "__author_email__",
 ]
 from astropy.units import Quantity, Unit
 
@@ -40,4 +37,4 @@ from .units import (
     as_quantity,
     convert,
 )
-from .version import __author__, __author_email__, __url__, __version__
+from .version import __version__

--- a/pandas_units_extension/__init__.py
+++ b/pandas_units_extension/__init__.py
@@ -19,6 +19,8 @@ Examples
 __all__ = [
     "as_quantity",
     "convert",
+    "InvalidUnitError",
+    "InvalidUnitConversionError",
     "Quantity",
     "UnitsDtype",
     "UnitsExtensionArray",
@@ -29,6 +31,12 @@ __all__ = [
 ]
 from astropy.units import Quantity, Unit
 
+from .units import (
+    InvalidUnit as InvalidUnitError,
+)
+from .units import (
+    InvalidUnitConversion as InvalidUnitConversionError,
+)
 from .units import (
     UnitsDataFrameAccessor,
     UnitsDtype,

--- a/pandas_units_extension/__init__.py
+++ b/pandas_units_extension/__init__.py
@@ -32,12 +32,8 @@ __all__ = [
 from astropy.units import Quantity, Unit
 
 from .units import (
-    InvalidUnit as InvalidUnitError,
-)
-from .units import (
-    InvalidUnitConversion as InvalidUnitConversionError,
-)
-from .units import (
+    InvalidUnitError,
+    InvalidUnitConversionError,
     UnitsDataFrameAccessor,
     UnitsDtype,
     UnitsExtensionArray,

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -16,14 +16,14 @@ from pandas.api.extensions import (
     register_dataframe_accessor,
     register_extension_dtype,
     register_series_accessor,
+    take,
 )
+from pandas.api.indexers import check_array_indexer
 from pandas.api.types import is_array_like, is_list_like, is_scalar
 from pandas.compat import set_function_name
 from pandas.core import nanops
-from pandas.core.algorithms import take
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndex, ABCSeries
 from pandas.core.indexers import (
-    check_array_indexer,
     getitem_returns_view,
 )
 from pandas.util._exceptions import find_stack_level

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -51,9 +51,14 @@ class InvalidUnitError(ValueError):
     """The unit does not exist."""
 
 
-# Temporary deprecated aliases
-InvalidUnitConversion = InvalidUnitConversionError
-InvalidUnit = InvalidUnitError
+@warnings.deprecated("Use InvalidUnitConversionError instead.")
+class InvalidUnitConversion(InvalidUnitConversionError):
+    pass
+
+
+@warnings.deprecated("Use InvalidUnitError instead.")
+class InvalidUnit(InvalidUnitError):
+    pass
 
 
 @register_extension_dtype

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -100,6 +100,8 @@ class UnitsDtype(ExtensionDtype):
 
     @property
     def name(self) -> str:
+        if self.unit is None:
+            return self.BASE_NAME
         return f"{self.BASE_NAME}[{self.unit.to_string()}]"
 
     @property
@@ -107,6 +109,8 @@ class UnitsDtype(ExtensionDtype):
         return u.Quantity(np.nan, self.unit)
 
     def __repr__(self) -> str:
+        if self.unit is None:
+            return f"{self.__class__.__name__}()"
         return f'{self.__class__.__name__}("{self.unit.to_string()}")'
 
     def _get_common_dtype(self, dtypes: list[DtypeObj]) -> DtypeObj | None:
@@ -565,7 +569,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         elif len(to_concat) == 1:
             return to_concat[0]
         elif len(set(item._unit for item in to_concat)) != 1:
-            # TODO: And this actually never happens.
+            # This actually never happens but left here for completeness.
             raise ValueError("Not all concatenated arrays have the same units.")
         else:
             return cls(

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -384,8 +384,9 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
     @classmethod
     def _from_sequence_of_strings(
-        cls, strings, dtype=None, copy=False
+        cls, strings, *, dtype=None, copy=False
     ) -> UnitsExtensionArray:
+        # Note: copy is ignored as we always convert the strings
         values: list[u.Quantity] = [u.Quantity(s) for s in strings]
         unit: UnitInstance = dtype.unit if dtype else None
         return UnitsExtensionArray(values, unit)

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -140,10 +140,10 @@ class UnitsDtype(ExtensionDtype):
             return self
 
         # Check that all types share the same physical type as self
-        phy_type: u.PhysicalType = (self.unit or u.Unit("")).physical_type
+        phy_type: u.PhysicalType = (self.unit or u.physical.dimensionless).physical_type
         if all(
             isinstance(t, UnitsDtype)
-            and (t.unit or u.Unit("")).physical_type == phy_type
+            and (t.unit or u.physical.dimensionless).physical_type == phy_type
             for t in dtypes
         ):
             return self

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -4,7 +4,7 @@ import operator
 import re
 import sys
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Literal, Self, TypeAlias
 
 import astropy.units as u
 import numpy as np
@@ -138,11 +138,9 @@ class UnitsDtype(ExtensionDtype):
         # Check that all types share the same physical type as self
         phy_type: u.PhysicalType = (self.unit or u.Unit("")).physical_type
         if all(
-            [
-                isinstance(t, UnitsDtype)
-                and (t.unit or u.Unit("")).physical_type == phy_type
-                for t in dtypes
-            ]
+            isinstance(t, UnitsDtype)
+            and (t.unit or u.Unit("")).physical_type == phy_type
+            for t in dtypes
         ):
             return self
 
@@ -486,13 +484,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # Fall-back to default variant
         return ExtensionArray.astype(self, dtype, copy=copy)
 
-    def view(self, dtype=None) -> UnitsExtensionArray:
+    def view(self, dtype=None) -> Self:
         """Create a new object with same data behind it."""
-        # TODO: Useful also for 0.25???
         if dtype is not None:
             # TODO: Perhaps implement?
             raise NotImplementedError(dtype)
-        result = UnitsExtensionArray.__new__(UnitsExtensionArray)
+        result = type(self).__new__(type(self))
         result._dtype = self.dtype
         result._value = self._value
         result._readonly = self._readonly
@@ -638,8 +635,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         return set_function_name(_binop, op_name, cls)
 
-    def copy(self, deep=False) -> UnitsExtensionArray:
-        return self.__class__(self._value, self._unit, copy=True)
+    def copy(self) -> Self:
+        return type(self)._simple_new(self._value.copy(), self.dtype)
 
     def _reduce(
         self, name: str, skipna: bool = True, keepdims: bool = False, **kwargs
@@ -688,8 +685,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self._value, None
 
     @classmethod
-    def _from_factorized(cls, values, original) -> UnitsExtensionArray:
-        return UnitsExtensionArray(values, original.dtype.unit)
+    def _from_factorized(cls, values, original) -> Self:
+        return cls(values, original.dtype.unit)
 
     def value_counts(
         self, normalize=False, sort=True, ascending=False, bins=None, dropna=True

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -215,19 +215,19 @@ def as_quantity(
     elif isinstance(obj, UnitsExtensionArray):
         return u.Quantity(obj._value, obj._unit, copy=copy)
     elif isinstance(obj, ABCSeries) and isinstance(obj.dtype, UnitsDtype):
-        return as_quantity(obj.array, copy=copy)
-    elif is_array_like(obj) and obj.dtype == "timedelta64[ns]":
+        return as_quantity(obj.array, copy=copy)  # type: ignore (We know it's a UnitsExtensionArray)
+    elif is_array_like(obj) and obj.dtype == "timedelta64[ns]":  # type: ignore (We know it has a dtype)
         # Note: Timedelta is internally represented as int64
         return u.Quantity(np.asarray(obj, dtype=np.int64), "ns", copy=copy).to("s")
     elif is_list_like(obj):
-        obj = list(obj)
+        obj = list(obj)  # type: ignore (a list-like object can be converted to list)
         copy = False  # Already copied by list()
         if len(obj) == 0:
             return u.Quantity([], "")
         elif all(isinstance(item, str) for item in obj):
             return u.Quantity([u.Quantity(item) for item in obj])
     if copy and hasattr(obj, "copy"):
-        obj = obj.copy()
+        obj = obj.copy()  # type: ignore
     return u.Quantity(obj)
 
 
@@ -644,12 +644,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         """Implementation of pandas basic reduce methods."""
         # Borrowed from IntegerArray
 
-        to_proxy: list[str] = ["min", "max", "sum", "mean", "std", "var"]
-        to_nanops: list[str] = ["median", "sem"]
-        to_error: list[str] = ["any", "all", "prod"]
+        to_proxy = ("min", "max", "sum", "mean", "std", "var")
+        to_nanops = ("median", "sem")
+        to_error = ("any", "all", "prod")
 
         # TODO: Check the dimension of this
-        to_implement_yet: list[str] = ["kurt", "skew"]
+        to_implement_yet = ("kurt", "skew")
 
         if name in to_proxy:
             q: u.Quantity = self.to_quantity()

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -4,7 +4,7 @@ import operator
 import re
 import sys
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Literal, Self, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 
 import astropy.units as u
 import numpy as np
@@ -245,15 +245,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         Parameters
         ----------
-        values : np.ndarray
-            The numerical values (without unit).
-        dtype : UnitsDtype
-            The dtype of the new array, which contains the unit information.
+        values : The numerical values (without unit).
+        dtype : The dtype of the new array, which contains the unit information.
 
         Returns
         -------
-        UnitsExtensionArray
-            A new UnitsExtensionArray with the given values and dtype.
+        A new UnitsExtensionArray with the given values and dtype.
         """
         result = UnitsExtensionArray.__new__(cls)
         result._dtype = dtype
@@ -489,12 +486,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # Fall-back to default variant
         return ExtensionArray.astype(self, dtype, copy=copy)
 
-    def view(self, dtype=None) -> Self:
+    def view(self, dtype=None) -> UnitsExtensionArray:
         """Create a new object with same data behind it."""
         if dtype is not None:
             # TODO: Perhaps implement?
             raise NotImplementedError(dtype)
-        result = type(self).__new__(type(self))
+        result = UnitsExtensionArray.__new__(type(self))
         result._dtype = self.dtype
         result._value = self._value
         result._readonly = self._readonly
@@ -559,19 +556,19 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         values = take(
             self._value, indices, allow_fill=allow_fill, fill_value=fill_value
         )
-        return UnitsExtensionArray(values, self._unit)
+        return UnitsExtensionArray._simple_new(values, self._dtype)
 
     @classmethod
     def _concat_same_type(cls, to_concat) -> UnitsExtensionArray:
         if len(to_concat) == 0:
-            return cls([])
+            return UnitsExtensionArray([])
         elif len(to_concat) == 1:
             return to_concat[0]
         elif len(set(item._unit for item in to_concat)) != 1:
             # This actually never happens but left here for completeness.
             raise ValueError("Not all concatenated arrays have the same units.")
         else:
-            return cls(
+            return UnitsExtensionArray(
                 np.concatenate([item._value for item in to_concat]), to_concat[0]._unit
             )
 
@@ -640,8 +637,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         return set_function_name(_binop, op_name, cls)
 
-    def copy(self) -> Self:
-        return type(self)._simple_new(self._value.copy(), self.dtype)
+    def copy(self) -> UnitsExtensionArray:
+        return UnitsExtensionArray._simple_new(self._value.copy(), self.dtype)
 
     def _reduce(
         self, name: str, skipna: bool = True, keepdims: bool = False, **kwargs
@@ -690,8 +687,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self._value, None
 
     @classmethod
-    def _from_factorized(cls, values, original) -> Self:
-        return cls(values, original.dtype.unit)
+    def _from_factorized(cls, values, original) -> UnitsExtensionArray:
+        return UnitsExtensionArray(values, original.dtype.unit)
 
     def value_counts(self, dropna=True) -> pd.Series:
         # Units preserved in the result index

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -4,6 +4,7 @@ import operator
 import re
 import sys
 import warnings
+from typing_extensions import deprecated  # warnings.deprecated is Python >= 3.13
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 
 import astropy.units as u
@@ -51,12 +52,12 @@ class InvalidUnitError(ValueError):
     """The unit does not exist."""
 
 
-@warnings.deprecated("Use InvalidUnitConversionError instead.")
+@deprecated("Use InvalidUnitConversionError instead.")
 class InvalidUnitConversion(InvalidUnitConversionError):
     pass
 
 
-@warnings.deprecated("Use InvalidUnitError instead.")
+@deprecated("Use InvalidUnitError instead.")
 class InvalidUnit(InvalidUnitError):
     pass
 

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -4,7 +4,7 @@ import operator
 import re
 import sys
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 
 import astropy.units as u
 import numpy as np
@@ -612,11 +612,11 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 return NotImplemented
 
             # Convert the thing to quantities
-            self_q: u.Quantity = as_quantity(self)
+            self_q = as_quantity(self)
 
             if op_name in ["__eq__", "__ne__"]:
                 try:
-                    other_q: u.Quantity = as_quantity(other)
+                    other_q = as_quantity(other)
                     if other_q.unit != self_q.unit:
                         # This enables comparison of temperature values
                         other_q = convert(other_q, self_q.unit)
@@ -625,7 +625,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                     # Compare things that cannot be converted to quantity, using astropy logic
                     return op(self_q, other)
 
-            other_q: u.Quantity = as_quantity(other)
+            other_q = as_quantity(other)
             if other_q.unit != self_q.unit:
                 # This enables comparison of temperature values
                 other_q = convert(other_q, self_q.unit)
@@ -670,6 +670,9 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         elif name in to_implement_yet:
             raise NotImplementedError
+
+        else:
+            raise ValueError(f"Invalid reduce operation: '{name}'")
 
         if keepdims:
             return self._from_scalars([result], dtype=self.dtype)

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -275,12 +275,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             unit: UnitInstance = u.Unit(unit)
 
         if q.unit.is_unity():
-            if unit:
-                q: u.Quantity = q * unit
-        elif unit and q.unit != unit:
+            if unit is not None:
+                q = q * unit
+        elif unit is not None and q.unit != unit:
             # Convert to target unit given by dtype as long as physical types match
             try:
-                q: u.Quantity = convert(q, unit)
+                q = convert(q, unit)
             except InvalidUnitConversion as e:
                 raise InvalidUnitConversion(
                     "Could not convert units in initialization of UnitsExtensionArray: "

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -539,12 +539,14 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         # Convert value to quantity and convert to same unit as self if necessary
         q: u.Quantity = as_quantity(value)
-        q: u.Quantity = convert(q, self._unit)
+        q = convert(q, self._unit)
 
         # Set the values at the given key to the numerical values of the quantity
         self._value[key] = q.value
 
-    def take(self, indices, allow_fill=False, fill_value=None) -> UnitsExtensionArray:
+    def take(
+        self, indices, *, allow_fill=False, fill_value=None
+    ) -> UnitsExtensionArray:
         """Integer-based selection of items."""
         if allow_fill:
             if fill_value is None or np.isnan(fill_value):

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -192,7 +192,7 @@ def convert(
 
 
 def as_quantity(
-    obj: ut.QuantityLike | UnitsExtensionArray, copy: bool = True
+    obj: ut.QuantityLike | UnitsExtensionArray | ABCSeries, copy: bool = True
 ) -> u.Quantity:
     """Try to convert whatever input to a Quantity.
 
@@ -200,7 +200,7 @@ def as_quantity(
     ----------
     obj : QuantityLike
         The object to convert to a Quantity. This can be a QuantityLike, a UnitsExtensionArray,
-        a timedelta64 array, or a list-like of strings that can be parsed as Quantities.
+        a timedelta64 array, or a list-like of strings, Series, that can be parsed as Quantities.
     copy : bool, default True
         Whether to copy the data if the input is already a Quantity or UnitsExtensionArray.
         This is ignored for list-like of strings, as they are already copied by list().

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -43,12 +43,17 @@ UnitInstance: TypeAlias = u.UnitBase | u.FunctionUnitBase
 u.imperial.enable()
 
 
-class InvalidUnitConversion(ValueError):
+class InvalidUnitConversionError(ValueError):
     """The unit cannot be converted to another one."""
 
 
-class InvalidUnit(ValueError):
+class InvalidUnitError(ValueError):
     """The unit does not exist."""
+
+
+# Temporary deprecated aliases
+InvalidUnitConversion = InvalidUnitConversionError
+InvalidUnit = InvalidUnitError
 
 
 @register_extension_dtype

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -527,24 +527,22 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def __setitem__(
         self, key, value: ut.QuantityLike | UnitsExtensionArray | None
     ) -> None:
-        # Return early if value is empty list or None, as this is a no-op for __setitem__
-        if (is_list_like(value) and len(value) == 0) or value is None:
-            return
-
-        # If readonly flag is set array cannot be modified in place, dispatch to pandas to comply with CoW
         if self._readonly:
             raise ValueError("Cannot modify read-only array")
 
-        # Convert NaN to Quantity with correct unit
+        # Convert None/NaN to Quantity with correct unit
+        if value is None:
+            value = np.nan
         if is_scalar(value) and np.isnan(value):
             value = u.Quantity(value, self._unit)
 
         # Use pandas utility function to check and convert the item to a valid indexer
         key = check_array_indexer(self, key)
 
-        # Convert value to quantity and convert to same unit as self if necessary
+        # Convert value to quantity and convert to same unit as self if necessary and possible
         q: u.Quantity = as_quantity(value)
-        q = convert(q, self._unit)
+        if q.isscalar or len(q) > 0:
+            q = convert(q, self._unit)
 
         # Set the values at the given key to the numerical values of the quantity
         self._value[key] = q.value

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -155,7 +155,7 @@ class UnitsDtype(ExtensionDtype):
             return None
 
         # Check that all types share the same physical type as self
-        phy_type: u.PhysicalType | None = _get_physical_type(self)
+        phy_type = _get_physical_type(self)
         if all(_get_physical_type(t) == phy_type for t in dtypes):
             return self
 

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -545,6 +545,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # Convert value to quantity and convert to same unit as self if necessary and possible
         q: u.Quantity = as_quantity(value)
         if q.isscalar or len(q) > 0:
+            # Note: empty quantity is dimensionless and cannot be converted to this dim
             q = convert(q, self._unit)
 
         # Set the values at the given key to the numerical values of the quantity

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -4,7 +4,7 @@ import operator
 import re
 import sys
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, cast
 
 import astropy.units as u
 import numpy as np
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         npt,
     )
 # In absence of a proper UnitBase class that also includes function units we define our own here
-UnitInstance: TypeAlias = u.UnitBase | u.FunctionUnitBase | None
+UnitInstance: TypeAlias = u.UnitBase | u.FunctionUnitBase
 
 # Imperial units enabled by default
 u.imperial.enable()
@@ -67,16 +67,14 @@ class UnitsDtype(ExtensionDtype):
     _is_numeric: bool = False
     _metadata: tuple[str] = ("unit",)
 
-    unit: UnitInstance
+    unit: UnitInstance | None
 
-    def __init__(self, unit: ut.UnitLike | None = None) -> None:
-        if isinstance(unit, (UnitInstance, type(None))):
-            self.unit = unit
-        else:
-            self.unit = u.Unit(unit)
+    def __init__(self, unit: UnitInstance | None = None) -> None:
+        self.unit = unit
 
     @classmethod
     def construct_from_string(cls, string: str) -> UnitsDtype:
+        """Parse 'unit', 'unit[]' and 'unit[...]' strings."""
         if not isinstance(string, str):
             raise TypeError(
                 f"'construct_from_string' expects a string, got {type(string)}"
@@ -88,10 +86,10 @@ class UnitsDtype(ExtensionDtype):
         )
         if not match:
             raise TypeError(f"Cannot construct a 'UnitsDtype' from '{string}'")
-        return cls(match["name"])
+        unit_string = match["name"]
+        return cls(u.Unit(unit_string))  # type: ignore[arg-type]
 
-    @classmethod
-    def construct_array_type(cls) -> type:
+    def construct_array_type(self) -> type:
         """Associated extension array."""
         return UnitsExtensionArray
 
@@ -132,13 +130,15 @@ class UnitsDtype(ExtensionDtype):
             # only itself
             return self
 
-        # Check that all dtypes are UnitsDtype
-        if not all([isinstance(t, UnitsDtype) for t in dtypes]):
-            return None
-
-        # Check that the units of all UnitsDtype have the same physical type as self and are therefore convertible to self
-        phy_type: u.PhysicalType = self.unit.physical_type
-        if all([t.unit.physical_type == phy_type for t in dtypes]):
+        # Check that all types share the same physical type as self
+        phy_type: u.PhysicalType = (self.unit or u.Unit("")).physical_type
+        if all(
+            [
+                isinstance(t, UnitsDtype)
+                and (t.unit or u.Unit("")).physical_type == phy_type
+                for t in dtypes
+            ]
+        ):
             return self
 
         # Different physical types, no common dtype

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -194,11 +194,11 @@ def convert(
         if q.unit.physical_type == "temperature":
             return q.to(new_unit, u.temperature())
         else:
-            raise InvalidUnitConversion(
+            raise InvalidUnitConversionError(
                 f"Cannot convert unit '{q.unit}' to '{new_unit}'."
             ) from None
     except ValueError:
-        raise InvalidUnit(f"Unit '{new_unit}' does not exist.") from None
+        raise InvalidUnitError(f"Unit '{new_unit}' does not exist.") from None
 
 
 def as_quantity(
@@ -288,8 +288,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             # Convert to target unit given by dtype as long as physical types match
             try:
                 q = convert(q, unit)
-            except InvalidUnitConversion as e:
-                raise InvalidUnitConversion(
+            except InvalidUnitConversionError as e:
+                raise InvalidUnitConversionError(
                     "Could not convert units in initialization of UnitsExtensionArray: "
                 ) from e
 
@@ -632,7 +632,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                         # This enables comparison of temperature values
                         other_q = convert(other_q, self_q.unit)
                     return op(self_q, other_q)
-                except (TypeError, InvalidUnitConversion):
+                except (TypeError, InvalidUnitConversionError):
                     # Compare things that cannot be converted to quantity, using astropy logic
                     return op(self_q, other)
 

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -4,6 +4,8 @@ import operator
 import re
 import sys
 import warnings
+
+from astropy.units import PhysicalType
 from typing_extensions import deprecated  # warnings.deprecated is Python >= 3.13
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 
@@ -145,13 +147,16 @@ class UnitsDtype(ExtensionDtype):
             # only itself
             return self
 
+        def _get_physical_type(dtype: Any) -> PhysicalType | None:
+            if isinstance(dtype, UnitsDtype):
+                if dtype.unit:
+                    return dtype.unit.physical_type
+                return u.physical.dimensionless
+            return None
+
         # Check that all types share the same physical type as self
-        phy_type: u.PhysicalType = (self.unit or u.physical.dimensionless).physical_type
-        if all(
-            isinstance(t, UnitsDtype)
-            and (t.unit or u.physical.dimensionless).physical_type == phy_type
-            for t in dtypes
-        ):
+        phy_type: u.PhysicalType | None = _get_physical_type(self)
+        if all(_get_physical_type(t) == phy_type for t in dtypes):
             return self
 
         # Different physical types, no common dtype

--- a/pandas_units_extension/version.py
+++ b/pandas_units_extension/version.py
@@ -1,6 +1,6 @@
 """Package information."""
 
-__version__ = "0.1.0"
-__url__ = "https://github.com/janpipek/pandas-units-extension"
-__author__ = "Jan Pipek"
-__author_email__ = "jan.pipek@gmail.com"
+from importlib.metadata import version
+
+__version__ = version("pandas_units_extension")
+__all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,11 @@ authors = [
     { name = "Julian Harbeck", email = "julian-harbeck@outlook.de" }
 ]
 requires-python = ">=3.11"
-dependencies = ["pandas>=3.0", "astropy>=5.1.1"]
+dependencies = [
+    "pandas>=3.0",
+    "astropy>=5.1.1",
+    "packaging>=22",
+]
 
 [project.urls]
 Homepage = "https://github.com/janpipek/pandas-units-extension"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pandas>=3.0",
     "astropy>=5.1.1",
     "packaging>=22",
+    "typing-extensions>=4.5.0",
 ]
 
 [project.urls]

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -689,6 +689,13 @@ class TestVarious(BaseExtensionTests):
         expected = pd.Series([u.Quantity("1 m"), u.Quantity("1 m/s")], dtype=object)
         tm.assert_series_equal(expected, concatenated)
 
+    def test_concat_no_unit(self):
+        s1 = pd.Series(["1 m"], dtype="unit")
+        s2 = pd.Series([2, 3])
+        concatenated = pd.concat([s1, s2]).reset_index(drop=True)
+        expected = pd.Series([u.Quantity("1 m"), 2, 3], dtype=object)
+        tm.assert_series_equal(expected, concatenated)
+
     @pytest.mark.xfail(
         Version(pd.__version__) < Version("3.1.0"),
         reason="Test fails on pandas below 3.1.0, see pandas GH #62523",

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
+from packaging.version import Version
 from pandas.core import ops, roperator
 from pandas.tests.extension import base
 from pandas.tests.extension.base import BaseOpsUtil
@@ -253,7 +254,7 @@ class TestDtype(base.BaseDtypeTests):
 
 class TestGroupBy(base.BaseGroupbyTests):
     @pytest.mark.xfail(
-        pd.__version__ < "3.1.0",
+        Version(pd.__version__) < Version("3.1.0"),
         reason="Test fails on pandas below 3.1.0, see pandas GH #64111",
     )
     def test_groupby_agg_extension(self, data_for_grouping):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -482,7 +482,7 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
 
 
 compare_scalar_mark_xfail: pytest.MarkDecorator = pytest.mark.xfail(
-    pd.__version__ < "3.1.0",
+    Version(pd.__version__) < Version("3.1.0"),
     reason="Test fails on pandas below 3.1.0, see pandas GH #64365",
 )
 
@@ -690,7 +690,7 @@ class TestVarious(BaseExtensionTests):
         tm.assert_series_equal(expected, concatenated)
 
     @pytest.mark.xfail(
-        pd.__version__ < "3.1.0",
+        Version(pd.__version__) < Version("3.1.0"),
         reason="Test fails on pandas below 3.1.0, see pandas GH #62523",
     )
     def test_add_new_value_with_different_unit(self):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -245,7 +245,10 @@ class TestCasting(base.BaseCastingTests):
 
 
 class TestDtype(base.BaseDtypeTests):
-    pass
+    @pytest.mark.parametrize(("f", "expected"), [(str, "unit"), (repr, "UnitsDtype()")])
+    def test_str_and_repr_without_unit(self, f, expected):
+        dtype = UnitsDtype()
+        assert f(dtype) == expected
 
 
 class TestGroupBy(base.BaseGroupbyTests):
@@ -532,7 +535,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             ordering_comparison_op(other, s)
 
     @pytest.mark.parametrize(
-        ("other", "result"),
+        ("other", "expected_equal"),
         [
             pytest.param(1, pd.Series([False, False]), id="number"),
             pytest.param("1 m", pd.Series([True, False]), id="string-as-unit"),
@@ -551,12 +554,12 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             ),
         ],
     )
-    def test_eq_ne(self, other, result, equality_comparison_op):
+    def test_eq_ne(self, other, expected_equal, equality_comparison_op):
         s = pd.Series([1, 2], dtype="unit[m]")
         if equality_comparison_op == operator.eq:
-            expected = result
+            expected = expected_equal
         else:
-            expected = ~result
+            expected = ~expected_equal
         result = equality_comparison_op(s, other)
         tm.assert_series_equal(result, expected)
 

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -133,7 +133,7 @@ def dtype():
 @pytest.fixture
 def na_cmp():
     # Note: np.nan != np.nan
-    def cmp(x, y):
+    def cmp(x: u.Quantity, y: u.Quantity) -> bool:
         if np.isnan(x.value):
             return np.isnan(y.value)
         else:

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -446,12 +446,18 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         self._check_divmod_op(ser[0], ops.rdivmod, ser)
 
     @pytest.mark.parametrize(
-        "op", [operator.mul, roperator.rmul, operator.truediv, roperator.rtruediv]
+        ("op", "expected_dtype"),
+        [
+            (operator.mul, "unit[m^2]"),
+            (roperator.rmul, "unit[m^2]"),
+            (operator.truediv, "unit[]"),
+            (roperator.rtruediv, "unit[]"),
+        ],
     )
-    def test_mul_div_with_unit(self, data, op):
+    def test_mul_div_with_unit(self, data, op, expected_dtype):
         s = pd.Series(data)
         result: pd.Series = op(s, u.m)
-        expected = pd.Series(op(data.to_quantity(), u.m), dtype="unit")
+        expected = pd.Series(op(data.to_quantity(), u.m), dtype=expected_dtype)
         tm.assert_series_equal(result, expected)
 
 

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -22,12 +22,12 @@ from pandas.tests.extension.conftest import (
     use_numpy,
 )
 
-from pandas_units_extension.units import (
+from pandas_units_extension import (
+    InvalidUnitConversionError,
     UnitsDtype,
     UnitsExtensionArray,
     UnitsSeriesAccessor,
     as_quantity,
-    InvalidUnitConversion,
 )
 
 _all_arithmetic_operators: list[str] = [
@@ -514,7 +514,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
         s2 = pd.Series([1000, 2000, 3000], dtype="unit[s]")
 
-        with pytest.raises(InvalidUnitConversion):
+        with pytest.raises(InvalidUnitConversionError):
             ordering_comparison_op(s1, s2)
 
     @pytest.mark.parametrize(
@@ -526,9 +526,9 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     )
     def test_with_incompatible_non_units(self, ordering_comparison_op, other):
         s = pd.Series([1000, 2000, 3000], dtype="unit[m]")
-        with pytest.raises(InvalidUnitConversion):
+        with pytest.raises(InvalidUnitConversionError):
             ordering_comparison_op(s, other)
-        with pytest.raises(InvalidUnitConversion):
+        with pytest.raises(InvalidUnitConversionError):
             ordering_comparison_op(other, s)
 
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ requires-dist = [
     { name = "astropy", specifier = ">=5.1.1" },
     { name = "packaging", specifier = ">=22" },
     { name = "pandas", specifier = ">=3.0" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,7 @@ dependencies = [
     { name = "astropy" },
     { name = "packaging" },
     { name = "pandas" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -241,6 +242,7 @@ requires-dist = [
     { name = "astropy", specifier = ">=5.1.1" },
     { name = "packaging", specifier = ">=22" },
     { name = "pandas", specifier = ">=3.0" },
+    { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -384,6 +386,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -226,6 +226,7 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
+    { name = "packaging" },
     { name = "pandas" },
 ]
 
@@ -238,6 +239,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=5.1.1" },
+    { name = "packaging", specifier = ">=22" },
     { name = "pandas", specifier = ">=3.0" },
 ]
 


### PR DESCRIPTION
## Issues to Address

### P0 — Fix immediately
- [x] `_reduce` fall-through: if `name` is not in any dispatch list, `result` is undefined → `UnboundLocalError` at runtime (`units.py:671–676`)
- [x] (FALSE POSITIVE) `_simple_new` never initialises `_readonly` → latent `AttributeError` on any path that reads it (`units.py:235–254`)

### P1 — Before next release
- [x] `isinstance(other, UnitInstance)` uses a `TypeAlias` union with `None` — silently matches `None` and calls `u.Quantity(1, None)` (`units.py:73, 591`)
- [x] `InvalidUnitConversion` and `InvalidUnit` not exported from the public `pandas_units_extension` namespace
- [ ] `u.imperial.enable()` at module import time mutates global astropy state with no opt-out (`units.py:43`)
- [x] (PARTLY) Six imports from `pandas.core.*` private internals (`set_function_name`, `nanops`, `take`, `ABCSeries`, `check_array_indexer`, `find_stack_level`) are a silent maintenance landmine (`units.py:21–29`)
- [x] (IRRELEVANT) Removing public `.unit` and `.value` properties (PR #26) without a `DeprecationWarning` cycle is a breaking API change

### P2 — Worth fixing soon
- [x] `UnitsDtype.name` and `__repr__` crash with `AttributeError` when `unit is None` (e.g. `UnitsDtype()`)
- [x] `all([list comprehension])` in `_get_common_dtype` materialises the full list before short-circuiting — drop the square brackets (`units.py:136, 141`)
- [x] (IGNORED) `_reduce` dispatch lists are recreated on every call — hoist to module-level `frozenset` constants (`units.py:645–650`)
- [x] `pd.__version__ < "3.1.0"` is a lexicographic comparison, wrong for future `3.10.x` — use `packaging.version.Version`
- [x] `view()` hardcodes `UnitsExtensionArray.__new__(UnitsExtensionArray)` instead of `type(self).__new__(type(self))` — breaks subclasses (`units.py:490–494`)
- [x] `if unit:` used where `if unit is not None:` is intended — falsy astropy unit objects would misbehave
- [ ] `__setitem__` silently no-ops on `value is None` with no explanation (`units.py:524`)
- [x] `test_mul_div_with_unit` uses `dtype="unit"` (no unit) for expected — never asserts the actual result unit
- [ ] `py.typed` declared but no type-checker (`mypy`/`pyright`) in CI — unverified promise
- [x] `as_quantity` type annotation does not include `pd.Series` after PR #27

### P3 — Nice to have
- [x] (IGNORED) `op_name = f"__{op.__name__}__"` relies on undocumented CPython naming convention — add a comment (`units.py:576`)
- [x] (IGNORED) `_concat_same_type` unit-mismatch check is believed dead (TODO comment) — remove or convert to `assert` (`units.py:558–569`)
- [x] `test_eq_ne` parameter named `result` is immediately shadowed by the actual result variable — rename to `expected_eq`
- [x] (COMMENTED) `_from_sequence_of_strings` accepts `copy` but does not forward it to the constructor
- [x] `copy` parameter is reassigned inside `as_quantity` for internal bookkeeping — use a separate local variable instead
- [x] Version `"0.1.0"` defined in both `pyproject.toml` and `version.py` — use `importlib.metadata.version()`
- [ ] No `src/` layout — tests run against working-directory package, not installed package
- [x] (FALSE POSITIVE) `na_cmp` test fixture accesses `.value` which looks like the renamed `_value` — add a disambiguating comment