### PR TITLE
Fix value_counts - the resulting index will contain the units as well (back by ExtensionArray)

### DIFF
--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -683,6 +683,13 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def _from_factorized(cls, values, original) -> UnitsExtensionArray:
         return UnitsExtensionArray(values, original.dtype.unit)
 
+    def value_counts(self, dropna=True) -> pd.Series:
+        # Units preserved in the result index
+        result = pd.Index(self._value).value_counts(dropna=dropna)
+        result_index = UnitsExtensionArray(result.index, self.dtype.unit)
+        result.index = result_index
+        return result
+
 
 UnitsExtensionArray._add_arithmetic_ops()
 UnitsExtensionArray._add_comparison_ops()

--- a/pandas_units_extension/units.py
+++ b/pandas_units_extension/units.py
@@ -683,14 +683,6 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def _from_factorized(cls, values, original) -> UnitsExtensionArray:
         return UnitsExtensionArray(values, original.dtype.unit)
 
-    def value_counts(
-        self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
-    ) -> pd.Series:
-        # TODO: Is it possible to include units? We'd need custom index
-        return pd.Index(self._value).value_counts(
-            normalize, sort, ascending, bins, dropna
-        )
-
 
 UnitsExtensionArray._add_arithmetic_ops()
 UnitsExtensionArray._add_comparison_ops()

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
+from astropy.constants.constant import Unit
 from pandas.core import ops, roperator
 from pandas.tests.extension import base
 from pandas.tests.extension.base import BaseOpsUtil
@@ -23,11 +24,11 @@ from pandas.tests.extension.conftest import (
 )
 
 from pandas_units_extension.units import (
+    InvalidUnitConversion,
     UnitsDtype,
     UnitsExtensionArray,
     UnitsSeriesAccessor,
     as_quantity,
-    InvalidUnitConversion,
 )
 
 _all_arithmetic_operators: list[str] = [
@@ -310,6 +311,21 @@ class TestMethods(base.BaseMethodsTests):
         assert arr.searchsorted(c) == 2
         assert arr.searchsorted(c, side="right") == 3
 
+    @pytest.mark.parametrize("dropna", [True, False])
+    def test_value_counts(self, all_data, dropna):
+        # Custom test required, as the parent removes the units info
+        s = pd.Series([1, 1, 2, np.nan], dtype="unit[m]")
+        result = s.value_counts(dropna=dropna)
+        expected_index = [1, 2] if dropna else [1, 2, np.nan]
+        expected_values = [2, 1] if dropna else [2, 1, 1]
+        expected = pd.Series(
+            expected_values,
+            index=UnitsExtensionArray(expected_index, unit=u.m),
+            dtype="int64",
+            name="count",
+        )
+        tm.assert_series_equal(result, expected)
+
 
 class TestReshaping(base.BaseReshapingTests):
     pass
@@ -404,19 +420,6 @@ class TestQuantile:
         source = pd.Series([1, 2, 3], dtype="unit[m]")
         result = source.quantile(0.5)
         assert result == 2.0 * u.m
-
-
-class TestValueCounts:
-    def test_value_counts_with_unit(self):
-        s = pd.Series([1, 1, 2], dtype="unit[m]")
-        vc = s.value_counts()
-        expected = pd.Series(
-            [2, 1],
-            index=UnitsExtensionArray([1 * u.m, 2 * u.m]),
-            dtype="int64",
-            name="count",
-        )
-        tm.assert_series_equal(vc, expected)
 
 
 class TestArithmeticsOps(base.BaseArithmeticOpsTests):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -406,6 +406,19 @@ class TestQuantile:
         assert result == 2.0 * u.m
 
 
+class TestValueCounts:
+    def test_value_counts_with_unit(self):
+        s = pd.Series([1, 1, 2], dtype="unit[m]")
+        vc = s.value_counts()
+        expected = pd.Series(
+            [2, 1],
+            index=UnitsExtensionArray([1 * u.m, 2 * u.m]),
+            dtype="int64",
+            name="count",
+        )
+        tm.assert_series_equal(vc, expected)
+
+
 class TestArithmeticsOps(base.BaseArithmeticOpsTests):
     divmod_exc = None
     series_scalar_exc = None

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
-from astropy.constants.constant import Unit
 from pandas.core import ops, roperator
 from pandas.tests.extension import base
 from pandas.tests.extension.base import BaseOpsUtil
@@ -311,13 +310,17 @@ class TestMethods(base.BaseMethodsTests):
         assert arr.searchsorted(c) == 2
         assert arr.searchsorted(c, side="right") == 3
 
-    @pytest.mark.parametrize("dropna", [True, False])
-    def test_value_counts(self, all_data, dropna):
+    @pytest.mark.parametrize(
+        ("dropna", "expected_index", "expected_values"),
+        [
+            pytest.param(True, [1, 2], [2, 1], id="dropna=True"),
+            pytest.param(False, [1, 2, np.nan], [2, 1, 1], id="dropna=False"),
+        ],
+    )
+    def test_value_counts(self, dropna, expected_index, expected_values):
         # Custom test required, as the parent removes the units info
         s = pd.Series([1, 1, 2, np.nan], dtype="unit[m]")
         result = s.value_counts(dropna=dropna)
-        expected_index = [1, 2] if dropna else [1, 2, np.nan]
-        expected_values = [2, 1] if dropna else [2, 1, 1]
         expected = pd.Series(
             expected_values,
             index=UnitsExtensionArray(expected_index, unit=u.m),


### PR DESCRIPTION
```
In [2]: x = pd.Series([1, 2, 3, 4, None], dtype="unit[m]")

In [3]: x.value_counts(dropna=True)
Out[3]:
1.0 m    1
2.0 m    1
3.0 m    1
4.0 m    1
Name: count, dtype: int64

In [4]: x.value_counts(dropna=False)
Out[4]:
1.0 m    1
2.0 m    1
3.0 m    1
4.0 m    1
nan m    1
Name: count, dtype: int64

In [5]: x.value_counts(dropna=False).index
Out[5]: Index([1.0 m, 2.0 m, 3.0 m, 4.0 m, nan m], dtype='unit[m]')
```