### PR TITLE
Fix the __array__ method

### DIFF
--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -317,7 +317,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return len(self._value)
 
     def __array__(
-        self, dtype: NpDtype | None = object, copy: bool | None = None
+        self, dtype: NpDtype | None = None, copy: bool | None = None
     ) -> np.ndarray:
         """
         Convert implicitly to a numpy array.

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         DtypeObj,
         NumpySorter,
         NumpyValueArrayLike,
+        NpDtype,
         npt,
     )
 # In absence of a proper UnitBase class that also includes function units we define our own here
@@ -316,7 +317,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return len(self._value)
 
     def __array__(
-        self, dtype: DtypeObj = object, copy: bool | None = None
+        self, dtype: NpDtype | None = object, copy: bool | None = None
     ) -> np.ndarray:
         """
         Convert implicitly to a numpy array.
@@ -325,7 +326,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         Parameters
         ----------
-        dtype : dtype, default object
+        dtype : dtype-like, default None
             The desired dtype for the array. If not given, will convert to object array containing Quantity objects.
             If given, will convert the numerical values to the given dtype and ignore the unit information.
         copy : bool, default None
@@ -337,6 +338,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             The array representation of the data.
         """
         # Create array depending on dtype
+        if dtype is None:
+            dtype = object
         if dtype == object:  # noqa: E721 (the equality is complex here)
             if copy is False:
                 raise ValueError(
@@ -345,10 +348,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             arr = np.array(list(as_quantity(self)), dtype=object)
             # Converting self first to a Quantity and then to a ndarray requires a copy, so copy flag will be set to True
             copy = True
-        elif dtype:
-            arr = self._value.astype(dtype, copy=copy)
         else:
-            arr = np.asarray(self._value, copy=copy)
+            arr = np.asarray(self._value, dtype=dtype, copy=copy)
 
         # Set writable flag depending on self._readonly and only when no copy was made
         if self._readonly and copy is not True:

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -326,7 +326,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         Parameters
         ----------
-        dtype : dtype-like, default None
+        dtype : dtype-like or None, default None
             The desired dtype for the array. If not given, will convert to object array containing Quantity objects.
             If given, will convert the numerical values to the given dtype and ignore the unit information.
         copy : bool, default None

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -767,16 +767,16 @@ class TestVarious(BaseExtensionTests):
             assert np.may_share_memory(result, expected) is False
 
 
-class TestArray:
+class TestArrayInterface:
     @pytest.mark.parametrize(
         ("copy", "dtype"),
         [
             (True, float),
             (False, float),
-            (False, float),
-            (True, "f"),
-            (None, int),
             (None, float),
+            (True, "f"),
+            (True, int),
+            (None, int),
             (True, "i"),
         ],
     )

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -765,3 +765,33 @@ class TestVarious(BaseExtensionTests):
         # We do not check the other case as a copy cannot always be prevented
         if copy:
             assert np.may_share_memory(result, expected) is False
+
+
+class TestArray:
+    @pytest.mark.parametrize(
+        ("copy", "dtype"),
+        [
+            (True, float),
+            (False, float),
+            (False, float),
+            (True, "f"),
+            (None, int),
+            (None, float),
+            (True, "i"),
+        ],
+    )
+    def test_allowed_numeric_conversions(self, data, dtype, copy):
+        result = np.array(data, dtype=dtype, copy=copy)
+        assert np.array_equal(result, [1, 2] + 8 * [3])
+
+    @pytest.mark.parametrize("copy", [True, None])
+    @pytest.mark.parametrize("dtype", [object, None, "O"])
+    def test_allowed_object_conversion(self, data, dtype, copy):
+        result = np.array(data, copy=True)
+        expected = np.array([1 * u.m, 2 * u.m] + 8 * [3 * u.m], dtype=object)
+        assert np.array_equal(result, expected)
+
+    @pytest.mark.parametrize("dtype", [int, None, object, "O", "i"])
+    def test_disallowed_conversions(self, data, dtype):
+        with pytest.raises(ValueError):
+            np.array(data, dtype=dtype, copy=False)


### PR DESCRIPTION
When fixing the typing information, I delved a bit into the array conversion and found out that the conversion function allows a "non-copy" conversion to int which obviously is a bug.

I simplified the function a bit, relying more on the asarray function of numpy.