### PR TITLE
DEPR: Deprecate global `u.imperial.enable()` while keeping imperial units functional for our usecase

### DIFF
--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -42,9 +42,6 @@ if TYPE_CHECKING:
 # In absence of a proper UnitBase class that also includes function units we define our own here
 UnitInstance: TypeAlias = u.UnitBase | u.FunctionUnitBase
 
-# Imperial units enabled by default
-u.imperial.enable()
-
 
 class InvalidUnitConversionError(ValueError):
     """
@@ -113,7 +110,8 @@ class UnitsDtype(ExtensionDtype):
         if not match:
             raise TypeError(f"Cannot construct a 'UnitsDtype' from '{string}'")
         unit_string = match["name"]
-        return cls(u.Unit(unit_string))  # type: ignore[arg-type]
+        with u.imperial.enable():
+            return cls(u.Unit(unit_string))  # type: ignore[arg-type]
 
     def construct_array_type(self) -> type[ExtensionArray]:
         return UnitsExtensionArray
@@ -162,7 +160,8 @@ def convert(
     """
     Convert quantity to a new unit.
 
-    Customized to be a bit more universal than the original quantities.
+    Customized to be a bit more universal than the original quantities by handling
+    imperial units and temperature equivalencies.
 
     Parameters
     ----------
@@ -186,17 +185,18 @@ def convert(
     InvalidUnitConversion
         If the conversion is invalid.
     """
-    try:
-        return q.to(new_unit, equivalencies or [])
-    except u.UnitConversionError:
-        if q.unit.physical_type == "temperature":
-            return q.to(new_unit, u.temperature())
-        else:
-            raise InvalidUnitConversionError(
-                f"Cannot convert unit '{q.unit}' to '{new_unit}'."
-            ) from None
-    except ValueError:
-        raise InvalidUnitError(f"Unit '{new_unit}' does not exist.") from None
+    with u.imperial.enable():
+        try:
+            return q.to(new_unit, equivalencies or [])
+        except u.UnitConversionError:
+            if q.unit.physical_type == "temperature":
+                return q.to(new_unit, u.temperature())
+            else:
+                raise InvalidUnitConversionError(
+                    f"Cannot convert unit '{q.unit}' to '{new_unit}'."
+                ) from None
+        except ValueError:
+            raise InvalidUnitError(f"Unit '{new_unit}' does not exist.") from None
 
 
 def as_quantity(
@@ -234,7 +234,8 @@ def as_quantity(
         if len(obj) == 0:
             return u.Quantity([], "")
         elif all(isinstance(item, str) for item in obj):
-            return u.Quantity([u.Quantity(item) for item in obj])
+            with u.imperial.enable():
+                return u.Quantity([u.Quantity(item) for item in obj])
     if copy and hasattr(obj, "copy"):
         obj = obj.copy()  # type: ignore
     return u.Quantity(obj)
@@ -284,7 +285,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             )
 
         if isinstance(unit, str):
-            unit: UnitInstance = u.Unit(unit)
+            with u.imperial.enable():
+                unit: UnitInstance = u.Unit(unit)
 
         if q.unit.is_unity():
             if unit is not None:

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -675,8 +675,14 @@ class TestVarious(BaseExtensionTests):
     @pytest.mark.parametrize(
         ("value", "expected"),
         [
-            pytest.param(1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"),
-            pytest.param(1 * u.imperial.ft, pd.Series(["1 m", "0.3048 m"], dtype="unit"), id="imperial-unit"),
+            pytest.param(
+                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"
+            ),
+            pytest.param(
+                1 * u.imperial.ft,
+                pd.Series(["1 m", "0.3048 m"], dtype="unit"),
+                id="imperial-unit",
+            ),
         ],
     )
     def test_concat_compatible(self, value, expected):
@@ -714,8 +720,14 @@ class TestVarious(BaseExtensionTests):
     @pytest.mark.parametrize(
         ("value", "expected"),
         [
-            pytest.param(1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"),
-            pytest.param(1 * u.imperial.ft, pd.Series(["1 m", "0.3048 m"], dtype="unit"), id="imperial-unit"),
+            pytest.param(
+                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"
+            ),
+            pytest.param(
+                1 * u.imperial.ft,
+                pd.Series(["1 m", "0.3048 m"], dtype="unit"),
+                id="imperial-unit",
+            ),
         ],
     )
     def test_add_new_value_with_different_unit(self, value, expected):
@@ -726,8 +738,14 @@ class TestVarious(BaseExtensionTests):
     @pytest.mark.parametrize(
         ("value", "expected"),
         [
-            pytest.param(1 * u.km, pd.Series(["1000 m"], dtype="unit"), id="standard-unit"),
-            pytest.param(1 * u.imperial.ft, pd.Series(["0.3048 m"], dtype="unit"), id="imperial-unit"),
+            pytest.param(
+                1 * u.km, pd.Series(["1000 m"], dtype="unit"), id="standard-unit"
+            ),
+            pytest.param(
+                1 * u.imperial.ft,
+                pd.Series(["0.3048 m"], dtype="unit"),
+                id="imperial-unit",
+            ),
         ],
     )
     def test_set_value_with_different_unit(self, value, expected):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -707,13 +707,15 @@ class TestVarious(BaseExtensionTests):
     )
     def test_add_new_value_with_different_unit(self):
         s1 = pd.Series(["1 m"], dtype="unit")
-        s1.at[1] = u.Quantity("1 ft")
+        with u.imperial.enable():
+            s1.at[1] = u.Quantity("1 ft")
         expected = pd.Series(["1.0 m", "0.3048 m"], dtype="unit")
         tm.assert_series_equal(expected, s1)
 
     def test_set_value_with_different_unit(self):
         s1 = pd.Series(["1 m"], dtype="unit")
-        s1[0] = u.Quantity("1 ft")
+        with u.imperial.enable():
+            s1[0] = u.Quantity("1 ft")
         expected = pd.Series(["0.3048 m"], dtype="unit")
         tm.assert_series_equal(expected, s1)
 
@@ -765,3 +767,19 @@ class TestVarious(BaseExtensionTests):
         # We do not check the other case as a copy cannot always be prevented
         if copy:
             assert np.may_share_memory(result, expected) is False
+
+    def test_imperial_units_not_globally_enabled(self):
+        """Test that imperial units are not enabled globally."""
+        with pytest.raises(ValueError, match="'ft' did not parse as unit"):
+            u.Quantity("1 ft")
+
+    def test_imperial_units_in_series(self):
+        """Test that imperial units can be used in a Series."""
+        pd.Series([1, 2, 3], dtype="unit[ft]")
+
+    def test_imperial_units_conversion(self, data):
+        """Test that ExtensionArray can be converted to imperial units."""
+        result = data.to("ft")
+        with u.imperial.enable():
+            expected = UnitsExtensionArray(data.to_quantity().to("ft"))
+        tm.assert_extension_array_equal(result, expected)

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -672,15 +672,21 @@ class TestUnitsDataFrameAccessor(BaseOpsUtil):
 
 
 class TestVarious(BaseExtensionTests):
-    def test_concat_compatible(self):
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"),
+            pytest.param(1 * u.imperial.ft, pd.Series(["1 m", "0.3048 m"], dtype="unit"), id="imperial-unit"),
+        ],
+    )
+    def test_concat_compatible(self, value, expected):
         """Test concatenation of Series with compatible units.
 
         Both units are of same physical type (length), expected values are converted to first unit, in this case meter.
         """
         s1 = pd.Series(["1 m"], dtype="unit")
-        s2 = pd.Series(["1 ft"], dtype="unit")
+        s2 = pd.Series([value], dtype="unit")
         concatenated = pd.concat([s1, s2]).reset_index(drop=True)
-        expected = pd.Series([1, 0.3048], dtype="unit[m]")
         tm.assert_series_equal(expected, concatenated)
 
     def test_concat_incompatible(self):
@@ -705,18 +711,28 @@ class TestVarious(BaseExtensionTests):
         Version(pd.__version__) < Version("3.1.0"),
         reason="Test fails on pandas below 3.1.0, see pandas GH #62523",
     )
-    def test_add_new_value_with_different_unit(self):
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"),
+            pytest.param(1 * u.imperial.ft, pd.Series(["1 m", "0.3048 m"], dtype="unit"), id="imperial-unit"),
+        ],
+    )
+    def test_add_new_value_with_different_unit(self, value, expected):
         s1 = pd.Series(["1 m"], dtype="unit")
-        with u.imperial.enable():
-            s1.at[1] = u.Quantity("1 ft")
-        expected = pd.Series(["1.0 m", "0.3048 m"], dtype="unit")
+        s1.at[1] = value
         tm.assert_series_equal(expected, s1)
 
-    def test_set_value_with_different_unit(self):
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(1 * u.km, pd.Series(["1000 m"], dtype="unit"), id="standard-unit"),
+            pytest.param(1 * u.imperial.ft, pd.Series(["0.3048 m"], dtype="unit"), id="imperial-unit"),
+        ],
+    )
+    def test_set_value_with_different_unit(self, value, expected):
         s1 = pd.Series(["1 m"], dtype="unit")
-        with u.imperial.enable():
-            s1[0] = u.Quantity("1 ft")
-        expected = pd.Series(["0.3048 m"], dtype="unit")
+        s1[0] = value
         tm.assert_series_equal(expected, s1)
 
     def test_unique(self):


### PR DESCRIPTION
Closes #38. As agreed in the issue all relevant code paths have been put behind `u.imperial.enable()` context managers. I also added the following tests to `TestVarious`:
- `test_imperial_units_not_globally_enabled`
- `test_imperial_units_in_series`
- `test_imperial_units_conversion`

Not sure if the following tests should still use `ft` or if they should be changed to `km` or some other unit enabled in astropy by default:
- `test_concat_compatible`
- `test_add_new_value_with_different_unit`
- `test_set_value_with_different_unit`