### PR TITLE
ENH: `astropy` umbrella framework, big rename, and Angle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,33 +21,50 @@ pip install -e .
 
 ## Examples
 
+Astropy-backed columns use the `astropy{<type>}[<params>]` dtype grammar. The
+only type currently available is `quantity` (an astropy `Quantity`), so a
+column of quantities is written `astropy{quantity}[<unit>]`. You can drop the
+selector and let the type be inferred from the parameters — `astropy[<unit>]`
+is equivalent as long as a single registered type can parse them. The matching
+`.astropy` accessor exposes the type-specific methods (`to`, `to_si`, `unit`,
+…) plus the common `to_astropy` / `to_table`.
+
 ```python
 >>> import pandas as pd
 >>> import pandas_units_extension as pue
 
 >>> temps = pd.DataFrame({
         "city": ["Prague", "Kathmandu", "Catania", "Boston"],
-        "temperature": pd.Series([20, 22, 31, 16], dtype="unit[deg_C]")
+        "temperature": pd.Series([20, 22, 31, 16], dtype="astropy{quantity}[deg_C]")
     })
->>> temps["temperature"].units.to("deg_F")
+>>> temps["temperature"].astropy.to("deg_F")
 0    68.0 deg_F
 1    71.6 deg_F
 2    87.8 deg_F
 3    60.8 deg_F
-Name: temperature, dtype: unit[deg_F]
+Name: temperature, dtype: astropy{quantity}[deg_F]
 
 
 >>> df = pd.DataFrame({
-        "distance": pd.Series([10, 12, 22, 18], dtype="unit[km]"),
-        "time": pd.Series([50, 60, 120, 108], dtype="unit[min]")
+        "distance": pd.Series([10, 12, 22, 18], dtype="astropy{quantity}[km]"),
+        "time": pd.Series([50, 60, 120, 108], dtype="astropy{quantity}[min]")
     })
 >>> speed = df["distance"] / df["time"]
->>> speed.units.to_si()
+>>> speed.astropy.to_si()
 0     3.333333333333334 m / s
 1     3.333333333333334 m / s
 2    3.0555555555555554 m / s
 3    2.7777777777777777 m / s
-dtype: unit[m / s]
+dtype: astropy{quantity}[m / s]
+```
+
+The bare `astropy` dtype infers the concrete type from native astropy data, and
+`pue.from_astropy` converts a native object directly:
+
+```python
+>>> import astropy.units as u
+>>> pd.Series([1 * u.m, 2 * u.m], dtype="astropy")   # inferred -> quantity
+>>> pue.from_astropy(u.Quantity([1, 2, 3], "m"))     # -> QuantityExtensionArray
 ```
 
 See [doc/units.ipynb](doc/units.ipynb) for more.

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ pip install -e .
 ## Examples
 
 Astropy-backed columns use the `astropy{<type>}[<params>]` dtype grammar. The
-only type currently available is `quantity` (an astropy `Quantity`), so a
-column of quantities is written `astropy{quantity}[<unit>]`. You can drop the
-selector and let the type be inferred from the parameters — `astropy[<unit>]`
-is equivalent as long as a single registered type can parse them. The matching
-`.astropy` accessor exposes the type-specific methods (`to`, `to_si`, `unit`,
-…) plus the common `to_astropy` / `to_table`.
+available types are `quantity` (an astropy `Quantity`) and `angle` (an astropy
+`Angle`), so columns are written `astropy{quantity}[<unit>]` /
+`astropy{angle}[<angular unit>]`. You can drop the selector and let the type be
+inferred from the parameters — `astropy[<unit>]` is equivalent as long as a
+single registered type can parse them. The matching `.astropy` accessor exposes
+the type-specific methods (`to`, `to_si`, `unit`, and — for angles — `wrap_at`,
+`dms`/`hms`, `is_within_bounds`) plus the common `to_astropy` / `to_table`.
 
 ```python
 >>> import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pandas-units-extension"
-version = "0.2.1"
+version = "0.3.0"
 description = "Extension pandas dtype and array for physical units and quantities from astropy."
 readme = "README.md"
 license = { text = "MIT" }
@@ -13,11 +13,14 @@ dependencies = [
     "pandas>=3.0",
     "astropy>=5.1.1",
     "packaging>=22",
-    "typing-extensions>=4.5.0",
 ]
 
 [project.urls]
 Homepage = "https://github.com/janpipek/pandas-units-extension"
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"
+testpaths = ["src", "tests"]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/pandas_units_extension/__init__.py
+++ b/src/pandas_units_extension/__init__.py
@@ -1,45 +1,63 @@
 """
-Extension pandas dtype and array for physical units.
+Extension pandas dtypes and arrays for astropy objects.
 
-It is based on astropy Quantities.
+The package exposes an ``astropy`` umbrella dtype and accessor. Concrete types
+are selected with the ``astropy{<type>}[<params>]`` grammar; currently the only
+type is ``quantity`` (an astropy :class:`~astropy.units.Quantity`). The selector
+may be omitted (``astropy[<params>]``) when the type can be inferred from the
+parameters.
 
 Examples
 --------
-    >>> pd.Series([1, 2, 3], dtype="unit[m]")
-    0   1.0 m
-    1   2.0 m
-    2   3.0 m
-    dtype: unit[m]
+    >>> import astropy.units as u
+    >>> import pandas as pd
+    >>> import pandas_units_extension  # registers the dtypes and accessors
+    >>> pd.Series([1, 2, 3], dtype="astropy{quantity}[m]")
+    0    1.0 m
+    1    2.0 m
+    2    3.0 m
+    dtype: astropy{quantity}[m]
 
-    >>> pd.Series([123, 21], dtype="unit[km]") / pd.Series([1, 3], dtype="unit[hour]")
-    0   123.0 km / h
-    1     7.0 km / h
-    dtype: unit[km / h]
+    >>> (
+    ...     pd.Series([123, 21], dtype="astropy{quantity}[km]")
+    ...     / pd.Series([1, 3], dtype="astropy{quantity}[hour]")
+    ... )
+    0    123.0 km / h
+    1      7.0 km / h
+    dtype: astropy{quantity}[km / h]
+
+    >>> pd.Series([1 * u.m, 2 * u.m], dtype="astropy")  # type inferred from data
+    0    1.0 m
+    1    2.0 m
+    dtype: astropy{quantity}[m]
 """
 
 __all__ = [
-    "as_quantity",
-    "convert",
+    "AstropyDtype",
+    "AstropyExtensionArray",
+    "AstropyDataFrameAccessor",
+    "QuantityDtype",
+    "QuantityExtensionArray",
+    "QuantitySeriesAccessor",
+    "from_astropy",
     "InvalidUnitError",
     "InvalidUnitConversionError",
-    "Quantity",
-    "UnitsDtype",
-    "UnitsExtensionArray",
-    "UnitsSeriesAccessor",
-    "UnitsDataFrameAccessor",
-    "Unit",
     "__version__",
 ]
-from astropy.units import Quantity, Unit
 
-from .units import (
-    InvalidUnitError,
+from .base import (
+    AstropyDataFrameAccessor,
+    AstropyDtype,
+    AstropyExtensionArray,
+    from_astropy,
+)
+
+# Importing the concrete types registers them with the registry.
+from .quantity import (
     InvalidUnitConversionError,
-    UnitsDataFrameAccessor,
-    UnitsDtype,
-    UnitsExtensionArray,
-    UnitsSeriesAccessor,
-    as_quantity,
-    convert,
+    InvalidUnitError,
+    QuantityDtype,
+    QuantityExtensionArray,
+    QuantitySeriesAccessor,
 )
 from .version import __version__

--- a/src/pandas_units_extension/__init__.py
+++ b/src/pandas_units_extension/__init__.py
@@ -2,10 +2,10 @@
 Extension pandas dtypes and arrays for astropy objects.
 
 The package exposes an ``astropy`` umbrella dtype and accessor. Concrete types
-are selected with the ``astropy{<type>}[<params>]`` grammar; currently the only
-type is ``quantity`` (an astropy :class:`~astropy.units.Quantity`). The selector
-may be omitted (``astropy[<params>]``) when the type can be inferred from the
-parameters.
+are selected with the ``astropy{<type>}[<params>]`` grammar; the available types
+are ``quantity`` (an astropy :class:`~astropy.units.Quantity`) and ``angle`` (an
+astropy :class:`~astropy.coordinates.Angle`). The selector may be omitted
+(``astropy[<params>]``) when the type can be inferred from the parameters.
 
 Examples
 --------
@@ -39,6 +39,9 @@ __all__ = [
     "QuantityDtype",
     "QuantityExtensionArray",
     "QuantitySeriesAccessor",
+    "AngleDtype",
+    "AngleExtensionArray",
+    "AngleSeriesAccessor",
     "from_astropy",
     "InvalidUnitError",
     "InvalidUnitConversionError",
@@ -59,5 +62,10 @@ from .quantity import (
     QuantityDtype,
     QuantityExtensionArray,
     QuantitySeriesAccessor,
+)
+from .angle import (
+    AngleDtype,
+    AngleExtensionArray,
+    AngleSeriesAccessor,
 )
 from .version import __version__

--- a/src/pandas_units_extension/_grammar.py
+++ b/src/pandas_units_extension/_grammar.py
@@ -1,0 +1,103 @@
+"""
+Parsing of the ``astropy`` dtype-string grammar.
+
+The grammar is::
+
+    astropy{<selector>}[<type-specific params>]
+
+where both the ``{selector}`` and the ``[params]`` parts are optional:
+
+- ``astropy``                 -> bare umbrella, type inferred from the data
+- ``astropy{quantity}``       -> concrete type, no parameters
+- ``astropy{quantity}[km/s]`` -> concrete type with parameters
+- ``astropy[km/s]``           -> type inferred from the parameters
+
+This module is intentionally free of any pandas or astropy imports so that the
+parser stays a pure, cheaply-testable function.
+"""
+
+import re
+from typing import NamedTuple
+
+# ``astropy`` followed by an optional ``{selector}`` and an optional ``[params]``.
+# The selector must be non-empty; the params may be empty (``astropy{quantity}[]``).
+_PATTERN: re.Pattern[str] = re.compile(
+    r"^astropy(?:\{(?P<selector>[^}]+)\})?(?:\[(?P<params>.*)\])?$"
+)
+
+
+class ParsedDtype(NamedTuple):
+    """
+    The result of parsing an ``astropy`` dtype string.
+
+    Attributes
+    ----------
+    selector : str or None
+        The type selector inside the braces (e.g. ``"quantity"``), or ``None``
+        for the bare ``astropy`` string.
+    params : str or None
+        The type-specific parameters inside the square brackets (e.g.
+        ``"km/s"``), or ``None`` when no brackets were given. May be the empty
+        string for ``astropy{quantity}[]``.
+
+    Examples
+    --------
+    >>> from pandas_units_extension._grammar import parse_dtype_string
+    >>> parsed = parse_dtype_string("astropy{quantity}[km/s]")
+    >>> parsed.selector
+    'quantity'
+    >>> parsed.params
+    'km/s'
+    """
+
+    selector: str | None
+    params: str | None
+
+
+def parse_dtype_string(string: str) -> ParsedDtype:
+    """
+    Parse an ``astropy`` dtype string into its selector and parameters.
+
+    Parameters
+    ----------
+    string : str
+        The dtype string to parse.
+
+    Returns
+    -------
+    ParsedDtype
+        The parsed selector and parameters.
+
+    Raises
+    ------
+    TypeError
+        If the string is not a valid ``astropy`` dtype string, i.e. anything not
+        starting with ``astropy`` (so that pandas' dtype registry falls through
+        to other dtypes).
+
+    Notes
+    -----
+    A string with parameters but no selector (``astropy[km/s]``) is valid; the
+    concrete type is inferred from the parameters by the caller.
+
+    Examples
+    --------
+    >>> parse_dtype_string("astropy{quantity}[km/s]")
+    ParsedDtype(selector='quantity', params='km/s')
+    >>> parse_dtype_string("astropy[km/s]")
+    ParsedDtype(selector=None, params='km/s')
+    >>> parse_dtype_string("astropy")
+    ParsedDtype(selector=None, params=None)
+    >>> parse_dtype_string("float64")
+    Traceback (most recent call last):
+        ...
+    TypeError: Cannot parse 'float64' as an astropy dtype string.
+    """
+    if not isinstance(string, str):
+        raise TypeError(f"'parse_dtype_string' expects a string, got {type(string)}")
+
+    match: re.Match[str] | None = _PATTERN.match(string)
+    if match is None:
+        raise TypeError(f"Cannot parse '{string}' as an astropy dtype string.")
+
+    return ParsedDtype(selector=match["selector"], params=match["params"])

--- a/src/pandas_units_extension/angle.py
+++ b/src/pandas_units_extension/angle.py
@@ -1,0 +1,219 @@
+"""
+The ``angle`` astropy type: pandas extension for :class:`astropy.coordinates.Angle`.
+
+``Angle`` is a :class:`~astropy.units.Quantity` subclass restricted to angular
+units, with extra methods (``wrap_at``, ``dms``/``hms``, ``is_within_bounds``).
+This module specialises the ``quantity`` classes accordingly and registers the
+``angle`` type so ``astropy{angle}[deg]`` / ``from_astropy(Angle(...))`` resolve
+to it.
+"""
+
+import astropy.units as u
+import pandas as pd
+from astropy.coordinates import Angle
+
+from .quantity import (
+    QuantityDtype,
+    QuantityExtensionArray,
+    QuantitySeriesAccessor,
+    UnitInstance,
+)
+from .registry import AstropyTypeSpec, register_astropy_type
+
+
+def _check_angular(unit: UnitInstance | None) -> None:
+    """Raise if ``unit`` is neither ``None`` nor an angular unit."""
+    if unit is not None and unit.physical_type != "angle":
+        raise ValueError(
+            f"AngleDtype requires an angular unit, got '{unit}' "
+            f"(physical type '{unit.physical_type}')."
+        )
+
+
+class AngleDtype(QuantityDtype):
+    """
+    Description of the angle type (``astropy{angle}[<angular unit>]``).
+
+    Like :class:`QuantityDtype` but restricted to angular units.
+
+    Parameters
+    ----------
+    unit : UnitInstance, optional
+        The (angular) physical unit of this dtype.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension import AngleDtype
+    >>> AngleDtype(u.deg)
+    AngleDtype("deg")
+    >>> AngleDtype(u.deg).name
+    'astropy{angle}[deg]'
+    >>> AngleDtype(u.m)
+    Traceback (most recent call last):
+        ...
+    ValueError: AngleDtype requires an angular unit, got 'm' (physical type 'length').
+    """
+
+    type: type = Angle
+    _selector: str = "angle"
+
+    def __init__(self, unit: UnitInstance | None = None) -> None:
+        _check_angular(unit)
+        super().__init__(unit)
+
+    def construct_array_type(self) -> type[QuantityExtensionArray]:
+        return AngleExtensionArray
+
+
+class AngleExtensionArray(QuantityExtensionArray):
+    """
+    Pandas extension array for astropy :class:`~astropy.coordinates.Angle` values.
+
+    Behaves like :class:`QuantityExtensionArray` but is restricted to angular
+    units, converts to :class:`~astropy.coordinates.Angle` via ``to_astropy`` and
+    exposes ``wrap_at``. Arithmetic whose result leaves the angular domain (e.g.
+    ``angle / angle``) degrades to a plain :class:`QuantityExtensionArray`.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension import AngleExtensionArray
+    >>> arr = AngleExtensionArray([350, 10], u.deg)
+    >>> arr.to_astropy()
+    <Angle [350.,  10.] deg>
+    >>> arr.wrap_at(180 * u.deg).to_astropy()
+    <Angle [-10.,  10.] deg>
+    """
+
+    _dtype_cls: "type[AngleDtype]" = AngleDtype
+
+    def _wrap_result(self, quantity: u.Quantity) -> QuantityExtensionArray:
+        # Stay an Angle only while the result is still angular; otherwise degrade.
+        if quantity.unit.physical_type == "angle":
+            return AngleExtensionArray(quantity)
+        return QuantityExtensionArray(quantity)
+
+    def to_astropy(self) -> Angle:
+        """
+        Convert to the native astropy object (an :class:`~astropy.coordinates.Angle`).
+
+        Returns
+        -------
+        Angle
+        """
+        return Angle(self.to_quantity())
+
+    def wrap_at(self, wrap_angle: "u.Quantity | str") -> "AngleExtensionArray":
+        """
+        Wrap the angles into the range ``[wrap_angle - 360 deg, wrap_angle)``.
+
+        Parameters
+        ----------
+        wrap_angle : Quantity or str
+            The wrap angle (e.g. ``180 * u.deg`` or ``"180d"``).
+
+        Returns
+        -------
+        AngleExtensionArray
+        """
+        return AngleExtensionArray(self.to_astropy().wrap_at(wrap_angle))
+
+
+class AngleSeriesAccessor(QuantitySeriesAccessor):
+    """
+    Accessor adding angle functionality to a Series (``series.astropy``).
+
+    Surfaced when the Series is backed by an :class:`AngleExtensionArray`. Adds
+    ``wrap_at``, the sexagesimal decompositions ``dms``/``hms``/``signed_dms``
+    (as DataFrames), and ``is_within_bounds`` on top of the inherited quantity
+    methods (``to_astropy`` -> ``Angle``, ``to``, ``to_si``, ``unit``).
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> import pandas as pd
+    >>> import pandas_units_extension
+    >>> s = pd.Series([350, 10], dtype="astropy{angle}[deg]")
+    >>> s.astropy.wrap_at(180 * u.deg)
+    0    -10.0 deg
+    1     10.0 deg
+    dtype: astropy{angle}[deg]
+    >>> pd.Series([10.5], dtype="astropy{angle}[deg]").astropy.dms
+          d     m    s
+    0  10.0  30.0  0.0
+    """
+
+    def wrap_at(self, wrap_angle: "u.Quantity | str") -> pd.Series:
+        """
+        Convert to a Series of angles wrapped at ``wrap_angle``.
+
+        Parameters
+        ----------
+        wrap_angle : Quantity or str
+            The wrap angle (e.g. ``180 * u.deg``).
+
+        Returns
+        -------
+        Series
+        """
+        return self._wrap(self._array.wrap_at(wrap_angle))
+
+    def _sexagesimal_frame(self, decomposition) -> pd.DataFrame:
+        """Turn a per-element ``(d, m, s)``-style namedtuple into a DataFrame."""
+        return pd.DataFrame(
+            {field: getattr(decomposition, field) for field in decomposition._fields},
+            index=self.series.index,
+        )
+
+    @property
+    def dms(self) -> pd.DataFrame:
+        """Sexagesimal degrees as a DataFrame with columns ``d``, ``m``, ``s``."""
+        return self._sexagesimal_frame(self._array.to_astropy().dms)
+
+    @property
+    def hms(self) -> pd.DataFrame:
+        """Sexagesimal hours as a DataFrame with columns ``h``, ``m``, ``s``."""
+        return self._sexagesimal_frame(self._array.to_astropy().hms)
+
+    @property
+    def signed_dms(self) -> pd.DataFrame:
+        """
+        Signed sexagesimal degrees as a DataFrame.
+
+        Columns are ``sign``, ``d``, ``m``, ``s`` with non-negative ``d``/``m``/``s``.
+        """
+        return self._sexagesimal_frame(self._array.to_astropy().signed_dms)
+
+    def is_within_bounds(
+        self,
+        lower: "u.Quantity | str | None" = None,
+        upper: "u.Quantity | str | None" = None,
+    ) -> bool:
+        """
+        Whether all angles are within the given bounds.
+
+        Parameters
+        ----------
+        lower, upper : Quantity or str or None
+            The (inclusive lower / exclusive upper) bounds; ``None`` disables that
+            side of the check.
+
+        Returns
+        -------
+        bool
+            ``True`` if every angle is within the bounds.
+        """
+        return self._array.to_astropy().is_within_bounds(lower, upper)
+
+
+register_astropy_type(
+    AstropyTypeSpec(
+        selector="angle",
+        native_type=Angle,
+        dtype_cls=AngleDtype,
+        array_cls=AngleExtensionArray,
+        series_accessor_cls=AngleSeriesAccessor,
+        parse_params=AngleDtype._parse_params,
+    )
+)

--- a/src/pandas_units_extension/angle.py
+++ b/src/pandas_units_extension/angle.py
@@ -62,7 +62,7 @@ class AngleDtype(QuantityDtype):
         _check_angular(unit)
         super().__init__(unit)
 
-    def construct_array_type(self) -> type[QuantityExtensionArray]:
+    def construct_array_type(self) -> "type[QuantityExtensionArray]":
         return AngleExtensionArray
 
 

--- a/src/pandas_units_extension/base.py
+++ b/src/pandas_units_extension/base.py
@@ -130,7 +130,7 @@ class AstropyDtype(ExtensionDtype):
             ) from None
         return spec.parse_params(parsed.params)
 
-    def construct_array_type(self) -> type[ExtensionArray]:
+    def construct_array_type(self) -> "type[ExtensionArray]":
         return AstropyExtensionArray
 
 

--- a/src/pandas_units_extension/base.py
+++ b/src/pandas_units_extension/base.py
@@ -1,0 +1,362 @@
+"""
+The ``astropy`` umbrella: base dtype, base array, accessors and ``from_astropy``.
+
+This module owns the generic machinery shared by every astropy-backed extension
+type. Concrete types (e.g. :mod:`~pandas_units_extension.quantity`) subclass
+:class:`AstropyDtype`/:class:`AstropyExtensionArray`/:class:`AstropySeriesAccessor`
+and register themselves through :mod:`~pandas_units_extension.registry`.
+
+Only the umbrella :class:`AstropyDtype` is registered with pandas. Its
+``construct_from_string`` is the single parser for the ``astropy{...}[...]``
+grammar and dispatches through the registry to the concrete dtype classes.
+"""
+
+from typing import Any
+
+import pandas as pd
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+    register_dataframe_accessor,
+    register_extension_dtype,
+    register_series_accessor,
+)
+
+from ._grammar import parse_dtype_string
+from .registry import (
+    get_by_selector,
+    infer_from_array,
+    infer_from_object,
+    infer_from_params,
+)
+
+
+@register_extension_dtype
+class AstropyDtype(ExtensionDtype):
+    """
+    Umbrella dtype for astropy-backed extension arrays.
+
+    The bare ``astropy`` string resolves to an (unresolved) instance of this
+    class, whose array type infers the concrete type from the data. Typed
+    strings like ``astropy{quantity}[m]`` are parsed here and dispatched through
+    the registry to a concrete :class:`AstropyDtype` subclass. A selector-less
+    ``astropy[m]`` resolves the concrete type from the parameters instead.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import astropy.units as u
+    >>> import pandas_units_extension  # registers the dtype with pandas
+    >>> pd.Series([1, 2, 3], dtype="astropy{quantity}[m]").dtype
+    QuantityDtype("m")
+    >>> pd.Series([1 * u.m, 2 * u.m], dtype="astropy").dtype  # inferred from data
+    QuantityDtype("m")
+    """
+
+    type: type = object
+    kind: str = "O"
+    _is_numeric: bool = False
+
+    @property
+    def name(self) -> str:
+        return "astropy"
+
+    @classmethod
+    def construct_from_string(cls, string: str) -> "AstropyDtype":
+        """
+        Parse an ``astropy`` dtype string and dispatch to the concrete dtype.
+
+        Parameters
+        ----------
+        string : str
+            The dtype string, e.g. ``"astropy"``, ``"astropy{quantity}"``,
+            ``"astropy{quantity}[m]"`` or ``"astropy[m]"`` (type inferred from
+            the parameters).
+
+        Returns
+        -------
+        AstropyDtype
+            The unresolved umbrella dtype for the bare ``"astropy"`` string, or a
+            concrete subclass instance (e.g. ``QuantityDtype``) for a typed one
+            or a parameter-only (``astropy[m]``) one.
+
+        Raises
+        ------
+        TypeError
+            If the string is not a valid ``astropy`` dtype string, names an
+            unknown type selector, or has parameters that no registered type can
+            parse.
+
+        Examples
+        --------
+        >>> AstropyDtype.construct_from_string("astropy{quantity}[m]")
+        QuantityDtype("m")
+        >>> AstropyDtype.construct_from_string("astropy[m]")  # type inferred
+        QuantityDtype("m")
+        >>> type(AstropyDtype.construct_from_string("astropy")).__name__
+        'AstropyDtype'
+        """
+        if not isinstance(string, str):
+            raise TypeError(
+                f"'construct_from_string' expects a string, got {type(string)}"
+            )
+        try:
+            parsed = parse_dtype_string(string)
+        except TypeError:
+            # Not an astropy dtype string (or malformed): let pandas' registry
+            # fall through to other dtypes.
+            raise TypeError(
+                f"Cannot construct a '{cls.__name__}' from '{string}'"
+            ) from None
+
+        if parsed.selector is None:
+            if parsed.params is None:
+                # Bare "astropy": unresolved umbrella, type inferred from data.
+                return AstropyDtype()
+            # "astropy[...]": infer the concrete type from the parameters.
+            dtype = infer_from_params(parsed.params)
+            if dtype is None:
+                raise TypeError(
+                    f"Cannot infer an astropy type from parameters "
+                    f"'{parsed.params}' in '{string}'."
+                )
+            return dtype
+
+        try:
+            spec = get_by_selector(parsed.selector)
+        except KeyError:
+            raise TypeError(
+                f"Unknown astropy type selector '{parsed.selector}' in '{string}'."
+            ) from None
+        return spec.parse_params(parsed.params)
+
+    def construct_array_type(self) -> type[ExtensionArray]:
+        return AstropyExtensionArray
+
+
+class AstropyExtensionArray(ExtensionArray):
+    """
+    Base class for astropy-backed pandas extension arrays.
+
+    Concrete subclasses (e.g. ``QuantityExtensionArray``) implement the actual
+    storage and override ``_from_sequence``/``_from_astropy``/``to_astropy``.
+    The base class itself is never instantiated; it only serves as the umbrella
+    array type that dispatches the bare-``astropy`` inference path.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import astropy.units as u
+    >>> import pandas_units_extension
+    >>> s = pd.Series([1 * u.m, 2 * u.m], dtype="astropy")  # umbrella dispatch
+    >>> type(s.array).__name__
+    'QuantityExtensionArray'
+    """
+
+    @classmethod
+    def _from_sequence(
+        cls, scalars, *, dtype=None, copy: bool = False
+    ) -> "AstropyExtensionArray":
+        if cls is not AstropyExtensionArray:
+            # A concrete subclass that forgot to override _from_sequence.
+            raise NotImplementedError(
+                f"{cls.__name__} must implement '_from_sequence'."
+            )
+
+        # Umbrella path (bare "astropy"): infer the concrete type from the data.
+        spec = _infer_spec_from_scalars(scalars)
+        if spec is None:
+            raise TypeError(
+                "Cannot infer astropy type from data. Write an explicit dtype "
+                "such as 'astropy{quantity}[m]' or use 'from_astropy'."
+            )
+        return spec.array_cls._from_sequence(scalars, dtype=None, copy=copy)
+
+    @classmethod
+    def _from_astropy(cls, obj: Any) -> "AstropyExtensionArray":
+        """Build the array from a native astropy object. Overridden by subclasses."""
+        raise NotImplementedError(f"{cls.__name__} must implement '_from_astropy'.")
+
+    def to_astropy(self) -> Any:
+        """Return the native astropy object backing this array. Overridden by subclasses."""
+        raise NotImplementedError(f"{type(self).__name__} must implement 'to_astropy'.")
+
+
+def _infer_spec_from_scalars(scalars):
+    """Find the registry spec matching the (first non-null) scalar of ``scalars``."""
+    spec = infer_from_object(scalars)
+    if spec is not None:
+        return spec
+    try:
+        iterator = iter(scalars)
+    except TypeError:
+        return None
+    for item in iterator:
+        spec = infer_from_object(item)
+        if spec is not None:
+            return spec
+    return None
+
+
+def from_astropy(obj: Any) -> AstropyExtensionArray:
+    """
+    Build the appropriate pandas extension array from a native astropy object.
+
+    Parameters
+    ----------
+    obj : object
+        A native astropy object (e.g. a :class:`~astropy.units.Quantity`).
+
+    Returns
+    -------
+    AstropyExtensionArray
+        The concrete extension array registered for ``type(obj)``.
+
+    Raises
+    ------
+    TypeError
+        If no registered astropy type handles ``obj``.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension import from_astropy
+    >>> from_astropy(u.Quantity([1, 2, 3], "m"))
+    <QuantityExtensionArray>
+    [1.0 m, 2.0 m, 3.0 m]
+    Length: 3, dtype: astropy{quantity}[m]
+    """
+    spec = infer_from_object(obj)
+    if spec is None:
+        raise TypeError(
+            f"No registered astropy extension type handles {type(obj).__name__}."
+        )
+    return spec.array_cls._from_astropy(obj)
+
+
+@register_series_accessor("astropy")
+class AstropySeriesAccessor:
+    """
+    Umbrella ``.astropy`` accessor for Series, dispatching by array type.
+
+    Accessing ``series.astropy`` returns the concrete accessor subclass
+    registered for the series' array (e.g. ``QuantitySeriesAccessor``). Common
+    methods such as :meth:`to_astropy` live here; type-specific methods live on
+    the subclasses and are simply absent (``AttributeError``) for other types.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import pandas_units_extension
+    >>> s = pd.Series([1, 2, 3], dtype="astropy{quantity}[m]")
+    >>> s.astropy.to_astropy()
+    <Quantity [1., 2., 3.] m>
+    >>> s.astropy.to("mm")
+    0    1000.0 mm
+    1    2000.0 mm
+    2    3000.0 mm
+    dtype: astropy{quantity}[mm]
+    """
+
+    series: pd.Series
+
+    def __new__(cls, series: pd.Series) -> "AstropySeriesAccessor":
+        if cls is AstropySeriesAccessor:
+            spec = infer_from_array(series.array)
+            if spec is None or spec.series_accessor_cls is None:
+                raise AttributeError(
+                    "Only astropy-backed Series have the 'astropy' accessor."
+                )
+            return object.__new__(spec.series_accessor_cls)
+        return object.__new__(cls)
+
+    def __init__(self, series: pd.Series) -> None:
+        self.series = series
+
+    @property
+    def _array(self) -> AstropyExtensionArray:
+        """Shortcut to the extension array of the series."""
+        return self.series.array  # type: ignore[return-value]
+
+    def to_astropy(self) -> Any:
+        """
+        Convert the series to its native astropy object.
+
+        Returns
+        -------
+        object
+            The native astropy object (e.g. a ``Quantity``).
+        """
+        return self._array.to_astropy()
+
+
+@register_dataframe_accessor("astropy")
+class AstropyDataFrameAccessor:
+    """
+    Umbrella ``.astropy`` accessor for DataFrames.
+
+    Parameters
+    ----------
+    df : DataFrame
+        The dataframe the accessor methods are applied on.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import pandas_units_extension
+    >>> df = pd.DataFrame({"a": pd.Series([1, 2, 3], dtype="astropy{quantity}[km]")})
+    >>> df.astropy.to_si()
+              a
+    0  1000.0 m
+    1  2000.0 m
+    2  3000.0 m
+    >>> df.astropy.to_table()["a"].unit
+    Unit("km")
+    """
+
+    df: pd.DataFrame
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+
+    def to_table(self):
+        """
+        Convert the DataFrame to an astropy :class:`~astropy.table.QTable`.
+
+        Each astropy-backed column contributes its native object (preserving
+        units etc.); other columns contribute their raw values. ``QTable`` is
+        used rather than :meth:`Table.from_pandas`, which drops units.
+
+        Returns
+        -------
+        QTable
+            A table with one column per DataFrame column.
+        """
+        from astropy.table import QTable
+
+        columns: dict[Any, Any] = {}
+        for name in self.df.columns:
+            col = self.df[name]
+            try:
+                columns[name] = col.astropy.to_astropy()
+            except AttributeError:
+                columns[name] = col.to_numpy()
+        return QTable(columns)
+
+    def to_si(self) -> pd.DataFrame:
+        """
+        Convert all astropy-backed columns that support it to SI units.
+
+        Returns
+        -------
+        DataFrame
+            A new DataFrame with convertible columns expressed in SI units.
+        """
+
+        def _f(col):
+            try:
+                return col.astropy.to_si()
+            except AttributeError:
+                return col
+
+        return self.df.apply(_f)

--- a/src/pandas_units_extension/quantity.py
+++ b/src/pandas_units_extension/quantity.py
@@ -1,35 +1,31 @@
-from __future__ import annotations
+"""
+The ``quantity`` astropy type: pandas extension for :class:`~astropy.units.Quantity`.
+
+This is the first concrete member of the ``astropy`` framework. It provides
+``QuantityDtype`` / ``QuantityExtensionArray`` / ``QuantitySeriesAccessor`` and
+registers itself with the shared registry so that the ``astropy{quantity}[...]``
+dtype grammar, ``from_astropy`` and the ``.astropy`` accessor all resolve to it.
+"""
 
 import operator
-import re
 import sys
 import warnings
-
-from astropy.units import PhysicalType
-from typing_extensions import deprecated  # warnings.deprecated is Python >= 3.13
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias
 
 import astropy.units as u
 import numpy as np
 import pandas as pd
-from pandas.api.extensions import (
-    ExtensionArray,
-    ExtensionDtype,
-    ExtensionScalarOpsMixin,
-    register_dataframe_accessor,
-    register_extension_dtype,
-    register_series_accessor,
-    take,
-)
+from pandas.api.extensions import ExtensionArray, ExtensionScalarOpsMixin, take
 from pandas.api.indexers import check_array_indexer
 from pandas.api.types import is_array_like, is_list_like, is_scalar
 from pandas.compat import set_function_name
 from pandas.core import nanops
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndex, ABCSeries
-from pandas.core.indexers import (
-    getitem_returns_view,
-)
+from pandas.core.indexers import getitem_returns_view
 from pandas.util._exceptions import find_stack_level
+
+from .base import AstropyDtype, AstropyExtensionArray, AstropySeriesAccessor
+from .registry import AstropyTypeSpec, register_astropy_type
 
 if TYPE_CHECKING:
     import astropy.units.typing as ut
@@ -40,6 +36,7 @@ if TYPE_CHECKING:
         NpDtype,
         npt,
     )
+
 # In absence of a proper UnitBase class that also includes function units we define our own here
 UnitInstance: TypeAlias = u.UnitBase | u.FunctionUnitBase
 
@@ -56,24 +53,13 @@ class InvalidUnitError(ValueError):
     """
 
 
-@deprecated("Use InvalidUnitConversionError instead.")
-class InvalidUnitConversion(InvalidUnitConversionError):
-    pass
-
-
-@deprecated("Use InvalidUnitError instead.")
-class InvalidUnit(InvalidUnitError):
-    pass
-
-
-@register_extension_dtype
-class UnitsDtype(ExtensionDtype):
+class QuantityDtype(AstropyDtype):
     """
-    Description of the units type.
+    Description of the quantity type.
 
-    The name is formed as "unit[.*]" where the inside of the square
-    brackets must be a unit name as understood by astropy units.
-    "unit" means the unit is not specified and will be extracted
+    The name is formed as ``astropy{quantity}[.*]`` where the inside of the
+    square brackets must be a unit name as understood by astropy units.
+    ``astropy{quantity}`` means the unit is not specified and will be extracted
     from the respective array.
 
     Parameters
@@ -82,9 +68,16 @@ class UnitsDtype(ExtensionDtype):
         The physical unit of this dtype
 
     TODO: reconsider the unspecified unit
-    """
 
-    BASE_NAME: str = "unit"
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension import QuantityDtype
+    >>> QuantityDtype(u.km / u.s)
+    QuantityDtype("km / s")
+    >>> QuantityDtype(u.m).name
+    'astropy{quantity}[m]'
+    """
 
     type: type = u.Quantity
     kind: str = "O"
@@ -97,31 +90,36 @@ class UnitsDtype(ExtensionDtype):
     def __init__(self, unit: UnitInstance | None = None) -> None:
         self.unit = unit
 
-    @classmethod
-    def construct_from_string(cls, string: str) -> UnitsDtype:
-        if not isinstance(string, str):
-            raise TypeError(
-                f"'construct_from_string' expects a string, got {type(string)}"
-            )
-        if string == cls.BASE_NAME:
-            return cls()
-        match: re.Match[str] | None = re.match(
-            f"{cls.BASE_NAME}\\[(?P<name>.*)\\]$", string
-        )
-        if not match:
-            raise TypeError(f"Cannot construct a 'UnitsDtype' from '{string}'")
-        unit_string = match["name"]
-        with u.imperial.enable():
-            return cls(u.Unit(unit_string))  # type: ignore[arg-type]
+    @staticmethod
+    def _parse_params(params: str | None) -> "QuantityDtype":
+        """
+        Build a ``QuantityDtype`` from the ``[params]`` part of a dtype string.
+
+        Parameters
+        ----------
+        params : str or None
+            The unit string (e.g. ``"km/s"`` or ``""``), or ``None`` when no
+            brackets were given (``astropy{quantity}``).
+
+        Returns
+        -------
+        QuantityDtype
+        """
+        if params is None:
+            unit = None
+        else:
+            with u.imperial.enable():
+                unit = u.Unit(params)
+        return QuantityDtype(unit)  # type: ignore[arg-type]
 
     def construct_array_type(self) -> type[ExtensionArray]:
-        return UnitsExtensionArray
+        return QuantityExtensionArray
 
     @property
     def name(self) -> str:
         if self.unit is None:
-            return self.BASE_NAME
-        return f"{self.BASE_NAME}[{self.unit.to_string()}]"
+            return "astropy{quantity}"
+        return f"astropy{{quantity}}[{self.unit.to_string()}]"
 
     @property
     def na_value(self) -> u.Quantity:
@@ -132,13 +130,13 @@ class UnitsDtype(ExtensionDtype):
             return f"{self.__class__.__name__}()"
         return f'{self.__class__.__name__}("{self.unit.to_string()}")'
 
-    def _get_common_dtype(self, dtypes: list[DtypeObj]) -> DtypeObj | None:
+    def _get_common_dtype(self, dtypes: "list[DtypeObj]") -> "DtypeObj | None":
         if len(set(dtypes)) == 1:
             # only itself
             return self
 
-        def _get_physical_type(dtype: Any) -> PhysicalType | None:
-            if isinstance(dtype, UnitsDtype):
+        def _get_physical_type(dtype: Any) -> u.PhysicalType | None:
+            if isinstance(dtype, QuantityDtype):
                 if dtype.unit:
                     return dtype.unit.physical_type
                 return u.physical.dimensionless
@@ -155,8 +153,8 @@ class UnitsDtype(ExtensionDtype):
 
 def convert(
     q: u.Quantity,
-    new_unit: ut.UnitLike,
-    equivalencies: list[tuple[ut.UnitLike, ut.UnitLike, Callable]] | None = None,
+    new_unit: "ut.UnitLike",
+    equivalencies: "list[tuple[ut.UnitLike, ut.UnitLike, Callable]] | None" = None,
 ) -> u.Quantity:
     """
     Convert quantity to a new unit.
@@ -181,10 +179,17 @@ def convert(
 
     Raises
     ------
-    InvalidUnit
+    InvalidUnitError
         When target unit does not exist.
-    InvalidUnitConversion
+    InvalidUnitConversionError
         If the conversion is invalid.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension.quantity import convert
+    >>> convert(u.Quantity([1, 2, 3], "km"), "m")
+    <Quantity [1000., 2000., 3000.] m>
     """
     with u.imperial.enable():
         try:
@@ -201,31 +206,40 @@ def convert(
 
 
 def as_quantity(
-    obj: ut.QuantityLike | UnitsExtensionArray | ABCSeries, copy: bool = True
+    obj: "ut.QuantityLike | QuantityExtensionArray | ABCSeries", copy: bool = True
 ) -> u.Quantity:
     """
     Convert whatever input to a Quantity.
 
     Parameters
     ----------
-    obj : QuantityLike or UnitsExtensionArray or Series
-        The object to convert to a Quantity. This can be a QuantityLike, a UnitsExtensionArray,
+    obj : QuantityLike or QuantityExtensionArray or Series
+        The object to convert to a Quantity. This can be a QuantityLike, a QuantityExtensionArray,
         a timedelta64 array, or a list-like of strings, Series, that can be parsed as Quantities.
     copy : bool, default True
-        Whether to copy the data if the input is already a Quantity or UnitsExtensionArray.
+        Whether to copy the data if the input is already a Quantity or QuantityExtensionArray.
         This is ignored for list-like of strings, as they are already copied by list().
 
     Returns
     -------
     Quantity
         The input converted to a Quantity.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension.quantity import as_quantity
+    >>> as_quantity([1, 2, 3] * u.m)
+    <Quantity [1., 2., 3.] m>
+    >>> as_quantity(["1 m", "2 m"])
+    <Quantity [1., 2.] m>
     """
     if isinstance(obj, u.Quantity):
         return u.Quantity(obj, copy=copy)
-    elif isinstance(obj, UnitsExtensionArray):
+    elif isinstance(obj, QuantityExtensionArray):
         return u.Quantity(obj._value, obj._unit, copy=copy)
-    elif isinstance(obj, ABCSeries) and isinstance(obj.dtype, UnitsDtype):
-        return as_quantity(obj.array, copy=copy)  # type: ignore (We know it's a UnitsExtensionArray)
+    elif isinstance(obj, ABCSeries) and isinstance(obj.dtype, QuantityDtype):
+        return as_quantity(obj.array, copy=copy)  # type: ignore (We know it's a QuantityExtensionArray)
     elif is_array_like(obj) and obj.dtype == "timedelta64[ns]":  # type: ignore (We know it has a dtype)
         # Note: Timedelta is internally represented as int64
         return u.Quantity(np.asarray(obj, dtype=np.int64), "ns", copy=copy).to("s")
@@ -242,36 +256,52 @@ def as_quantity(
     return u.Quantity(obj)
 
 
-class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
+class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
     """
     Pandas extension array supporting physical quantities with units based on the astropy.units package.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension import QuantityExtensionArray
+    >>> arr = QuantityExtensionArray([1, 2, 3], u.m)
+    >>> arr
+    <QuantityExtensionArray>
+    [1.0 m, 2.0 m, 3.0 m]
+    Length: 3, dtype: astropy{quantity}[m]
+    >>> arr.to_astropy()
+    <Quantity [1., 2., 3.] m>
+    >>> arr.to("mm").to_astropy()
+    <Quantity [1000., 2000., 3000.] mm>
     """
 
-    # Adapted from MaskedArray to create new objects of UnitsExtensionArray for views and slices
+    # Adapted from MaskedArray to create new objects of QuantityExtensionArray for views and slices
     @classmethod
-    def _simple_new(cls, values: np.ndarray, dtype: UnitsDtype) -> UnitsExtensionArray:
+    def _simple_new(
+        cls, values: np.ndarray, dtype: QuantityDtype
+    ) -> "QuantityExtensionArray":
         """
-        Create a new UnitsExtensionArray from the given values and dtype.
+        Create a new QuantityExtensionArray from the given values and dtype.
 
         Parameters
         ----------
         values : np.ndarray
             The numerical values (without unit).
-        dtype : UnitsDtype
+        dtype : QuantityDtype
             The dtype of the new array, which contains the unit information.
 
         Returns
         -------
-        UnitsExtensionArray
-            A new UnitsExtensionArray with the given values and dtype.
+        QuantityExtensionArray
+            A new QuantityExtensionArray with the given values and dtype.
         """
-        result = UnitsExtensionArray.__new__(cls)
+        result = QuantityExtensionArray.__new__(cls)
         result._dtype = dtype
         result._value = values
         return result
 
     def __init__(
-        self, array, unit: ut.UnitLike | None = None, *, copy: bool = True
+        self, array, unit: "ut.UnitLike | None" = None, *, copy: bool = True
     ) -> None:
         q: u.Quantity = as_quantity(array, copy=copy)
 
@@ -282,7 +312,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # after comparison operations. The raised ValueError is caught there and handled properly.
         if isinstance(q.dtype, np.dtypes.BoolDType):
             raise ValueError(
-                "Boolean array cannot sensible be converted to Quantity and therefore UnitsExtensionArray."
+                "Boolean array cannot sensible be converted to Quantity and therefore QuantityExtensionArray."
             )
 
         if isinstance(unit, str):
@@ -298,10 +328,10 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 q = convert(q, unit)
             except InvalidUnitConversionError as e:
                 raise InvalidUnitConversionError(
-                    "Could not convert units in initialization of UnitsExtensionArray: "
+                    "Could not convert units in initialization of QuantityExtensionArray: "
                 ) from e
 
-        self._dtype: UnitsDtype = UnitsDtype(q.unit)
+        self._dtype: QuantityDtype = QuantityDtype(q.unit)
         self._value: np.ndarray[np.float64] = q.value.astype(float)
 
     @property
@@ -312,14 +342,14 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self.dtype.unit
 
     @property
-    def dtype(self) -> UnitsDtype:
+    def dtype(self) -> QuantityDtype:
         return self._dtype
 
     def __len__(self) -> int:
         return len(self._value)
 
     def __array__(
-        self, dtype: NpDtype | None = None, copy: bool | None = None
+        self, dtype: "NpDtype | None" = None, copy: bool | None = None
     ) -> np.ndarray:
         """
         Convert implicitly to a numpy array.
@@ -373,13 +403,13 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         bool
             Whether the item is in the array.
         """
-        # Check if item is a Quantity object, if not it cannot be in the UnitsExtensionArray
+        # Check if item is a Quantity object, if not it cannot be in the QuantityExtensionArray
         if not isinstance(item, u.Quantity):
             return False
 
         # Check if item is na_value by checking if the item is scalar through the ndim parameter and nan
         if item.ndim == 0 and np.isnan(item):
-            # Check that the physical type of the unit of the nan Quantity is the same as that of UnitsExtensionArray.
+            # Check that the physical type of the unit of the nan Quantity is the same as that of QuantityExtensionArray.
             # Here we are a bit flexible so `np.nan * u.cm` is considered to be the same as `np.nan * u.m` as the value
             # of the Quantity and therefore the scaling of the unit does not really matter for nan.
             if item.unit.physical_type == self._unit.physical_type:
@@ -392,24 +422,23 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self._value.nbytes + sys.getsizeof(self._unit)
 
     @classmethod
-    def _from_sequence(cls, scalars, dtype=None, copy=False) -> UnitsExtensionArray:
-        if dtype:
-            result = cls(scalars, unit=dtype.unit, copy=copy)
-        else:
-            result = cls(scalars, copy=copy)
-        return result
+    def _from_sequence(
+        cls, scalars, dtype=None, copy=False
+    ) -> "QuantityExtensionArray":
+        unit = dtype.unit if dtype else None
+        return cls(scalars, unit=unit, copy=copy)
 
     @classmethod
     def _from_sequence_of_strings(
         cls, strings, *, dtype=None, copy=False
-    ) -> UnitsExtensionArray:
+    ) -> "QuantityExtensionArray":
         # Note: copy is ignored as we always convert the strings
         values: list[u.Quantity] = [u.Quantity(s) for s in strings]
         unit: UnitInstance = dtype.unit if dtype else None
-        return UnitsExtensionArray(values, unit)
+        return QuantityExtensionArray(values, unit)
 
     @classmethod
-    def _from_scalars(cls, scalars, *, dtype=None) -> UnitsExtensionArray:
+    def _from_scalars(cls, scalars, *, dtype=None) -> "QuantityExtensionArray":
         # Contrary to the superclass, this function will ignore the `dtype`
         # if given, and will always try to infer the `dtype` from the scalars.
         # This is due to arithmetic operation that are changing the unit and
@@ -418,7 +447,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # original `dtype` of the left operand, not necessarily the correct
         # `dtype` of the result.
         try:
-            result: UnitsExtensionArray = cls._from_sequence(scalars)
+            result: QuantityExtensionArray = cls._from_sequence(scalars)
         except (ValueError, TypeError):
             raise
         except Exception:
@@ -442,15 +471,29 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         """
         return as_quantity(self)
 
-    def unique(self) -> UnitsExtensionArray:
+    def to_astropy(self) -> u.Quantity:
+        """
+        Convert to the native astropy object (a Quantity).
+
+        Returns
+        -------
+        Quantity
+        """
+        return self.to_quantity()
+
+    @classmethod
+    def _from_astropy(cls, obj: u.Quantity) -> "QuantityExtensionArray":
+        return cls(as_quantity(obj))
+
+    def unique(self) -> "QuantityExtensionArray":
         return self.__class__(pd.unique(self._value), unit=self._unit)
 
     def searchsorted(
         self,
-        value: NumpyValueArrayLike | u.Quantity | UnitsExtensionArray,
+        value: "NumpyValueArrayLike | u.Quantity | QuantityExtensionArray",
         side: Literal["left", "right"] = "left",
-        sorter: NumpySorter | None = None,
-    ) -> npt.NDArray[np.intp] | np.intp:
+        sorter: "NumpySorter | None" = None,
+    ) -> "npt.NDArray[np.intp] | np.intp":
         # Convert self and the value to a Quantity
         self_q: u.Quantity = as_quantity(self)
         value_q: u.Quantity = as_quantity(value)
@@ -460,9 +503,9 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
     def to(
         self,
-        new_unit: ut.UnitLike,
-        equivalencies: list[tuple[ut.UnitLike, ut.UnitLike, Callable]] | None = None,
-    ) -> UnitsExtensionArray:
+        new_unit: "ut.UnitLike",
+        equivalencies: "list[tuple[ut.UnitLike, ut.UnitLike, Callable]] | None" = None,
+    ) -> "QuantityExtensionArray":
         """
         Convert to another unit (if possible).
 
@@ -475,20 +518,20 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         Returns
         -------
-        UnitsExtensionArray
+        QuantityExtensionArray
             A new extension array with converted units
         """
         q: u.Quantity = self.to_quantity()
         new_data: u.Quantity = convert(q, new_unit, equivalencies)
-        return UnitsExtensionArray(new_data)
+        return QuantityExtensionArray(new_data)
 
     def astype(self, dtype, copy: bool = True):
-        def _as_units_dtype(unit: UnitInstance) -> UnitsExtensionArray:
+        def _as_units_dtype(unit: UnitInstance) -> "QuantityExtensionArray":
             return self.to(unit)
 
         if dtype == self.dtype:
             return self.copy() if copy else self
-        elif isinstance(dtype, UnitsDtype):
+        elif isinstance(dtype, QuantityDtype):
             return _as_units_dtype(dtype.unit)
         elif dtype == "timedelta64[ns]":
             nanoseconds: u.Quantity = convert(as_quantity(self, copy=copy), "ns")
@@ -500,7 +543,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             return np.array([x * self._unit for x in self._value], dtype=object)
         elif isinstance(dtype, str):
             try:
-                dtype = UnitsDtype(dtype)
+                dtype = QuantityDtype(dtype)
                 return _as_units_dtype(dtype.unit)
             except Exception:
                 pass
@@ -508,11 +551,11 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # Fall-back to default variant
         return ExtensionArray.astype(self, dtype, copy=copy)
 
-    def view(self, dtype=None) -> UnitsExtensionArray:
+    def view(self, dtype=None) -> "QuantityExtensionArray":
         if dtype is not None:
             # TODO: Perhaps implement?
             raise NotImplementedError(dtype)
-        result = UnitsExtensionArray.__new__(type(self))
+        result = QuantityExtensionArray.__new__(type(self))
         result._dtype = self.dtype
         result._value = self._value
         result._readonly = self._readonly
@@ -521,7 +564,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def _formatter(self, boxed: bool = False):
         return lambda x: str(x) if isinstance(x, u.Quantity) else f"{x} {self._unit}"
 
-    def __getitem__(self, item) -> u.Quantity | UnitsExtensionArray:
+    def __getitem__(self, item) -> "u.Quantity | QuantityExtensionArray":
         # Return zerodim Quantity object for singular item
         if is_scalar(item):
             return u.Quantity(self._value[item], unit=self._unit)
@@ -529,8 +572,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         # Use pandas utility function to check and convert the item to a valid indexer
         item = check_array_indexer(self, item)
 
-        # Create new UnitsExtensionArray
-        result: UnitsExtensionArray = self._simple_new(self._value[item], self.dtype)
+        # Create new QuantityExtensionArray
+        result: QuantityExtensionArray = self._simple_new(self._value[item], self.dtype)
 
         # If the result is a view, keep read-only flag
         if getitem_returns_view(self, item):
@@ -539,7 +582,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return result
 
     def __setitem__(
-        self, key, value: ut.QuantityLike | UnitsExtensionArray | None
+        self, key, value: "ut.QuantityLike | QuantityExtensionArray | None"
     ) -> None:
         if self._readonly:
             raise ValueError("Cannot modify read-only array")
@@ -564,7 +607,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
     def take(
         self, indices, *, allow_fill=False, fill_value=None
-    ) -> UnitsExtensionArray:
+    ) -> "QuantityExtensionArray":
         if allow_fill:
             if fill_value is None or np.isnan(fill_value):
                 fill_value = np.nan
@@ -573,19 +616,19 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         values = take(
             self._value, indices, allow_fill=allow_fill, fill_value=fill_value
         )
-        return UnitsExtensionArray._simple_new(values, self._dtype)
+        return QuantityExtensionArray._simple_new(values, self._dtype)
 
     @classmethod
-    def _concat_same_type(cls, to_concat) -> UnitsExtensionArray:
+    def _concat_same_type(cls, to_concat) -> "QuantityExtensionArray":
         if len(to_concat) == 0:
-            return UnitsExtensionArray([])
+            return QuantityExtensionArray([])
         elif len(to_concat) == 1:
             return to_concat[0]
         elif len(set(item._unit for item in to_concat)) != 1:
             # This actually never happens but left here for completeness.
             raise ValueError("Not all concatenated arrays have the same units.")
         else:
-            return UnitsExtensionArray(
+            return QuantityExtensionArray(
                 np.concatenate([item._value for item in to_concat]), to_concat[0]._unit
             )
 
@@ -654,12 +697,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
 
         return set_function_name(_binop, op_name, cls)
 
-    def copy(self) -> UnitsExtensionArray:
-        return UnitsExtensionArray._simple_new(self._value.copy(), self.dtype)
+    def copy(self) -> "QuantityExtensionArray":
+        return QuantityExtensionArray._simple_new(self._value.copy(), self.dtype)
 
     def _reduce(
         self, name: str, skipna: bool = True, keepdims: bool = False, **kwargs
-    ) -> UnitsExtensionArray | u.Quantity:
+    ) -> "QuantityExtensionArray | u.Quantity":
         # Borrowed from IntegerArray
 
         to_proxy = ("min", "max", "sum", "mean", "std", "var")
@@ -702,41 +745,49 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
         return self._value, None
 
     @classmethod
-    def _from_factorized(cls, values, original) -> UnitsExtensionArray:
-        return UnitsExtensionArray(values, original.dtype.unit)
+    def _from_factorized(cls, values, original) -> "QuantityExtensionArray":
+        return QuantityExtensionArray(values, original.dtype.unit)
 
     def value_counts(self, dropna=True) -> pd.Series:
         # Units preserved in the result index
         result = pd.Index(self._value).value_counts(dropna=dropna)
-        result_index = UnitsExtensionArray(result.index, self.dtype.unit)
+        result_index = QuantityExtensionArray(result.index, self.dtype.unit)
         result.index = result_index
         return result
 
 
-UnitsExtensionArray._add_arithmetic_ops()
-UnitsExtensionArray._add_comparison_ops()
-UnitsExtensionArray.__pow__ = UnitsExtensionArray._create_arithmetic_method(
+QuantityExtensionArray._add_arithmetic_ops()
+QuantityExtensionArray._add_comparison_ops()
+QuantityExtensionArray.__pow__ = QuantityExtensionArray._create_arithmetic_method(
     operator.pow
 )
 
 
-@register_series_accessor("units")
-class UnitsSeriesAccessor:
+class QuantitySeriesAccessor(AstropySeriesAccessor):
     """
-    Accessor adding unit functionality to series.
+    Accessor adding quantity functionality to a Series (``series.astropy``).
 
-    Parameters
-    ----------
-    series : Series[UnitsExtensionArray]
-        The series the accessor methods are applied on.
+    Surfaced when the Series is backed by a :class:`QuantityExtensionArray`.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import pandas_units_extension
+    >>> s = pd.Series([1, 2, 3], dtype="astropy{quantity}[km]")
+    >>> s.astropy.unit
+    Unit("km")
+    >>> s.astropy.to_si()
+    0    1000.0 m
+    1    2000.0 m
+    2    3000.0 m
+    dtype: astropy{quantity}[m]
     """
 
-    series: pd.Series[UnitsExtensionArray]
-
-    def __init__(self, series: pd.Series[UnitsExtensionArray]) -> None:
-        if not isinstance(series.array, UnitsExtensionArray):
-            raise AttributeError("Only UnitsExtensionArray has units accessor.")
-        self.series = series
+    def _wrap(self, result: QuantityExtensionArray) -> pd.Series:
+        """
+        Construct a series with different data but the same index and name.
+        """
+        return pd.Series(result, name=self.series.name, index=self.series.index)
 
     @property
     def unit(self) -> UnitInstance:
@@ -749,23 +800,10 @@ class UnitsSeriesAccessor:
         """
         return self._array._unit
 
-    @property
-    def _array(self) -> UnitsExtensionArray:
-        """
-        Shortcut to the extension array of the series.
-        """
-        return self.series.array  # type: ignore
-
-    def _wrap(self, result: UnitsExtensionArray) -> pd.Series:
-        """
-        Construct a series with different data but the same index and name.
-        """
-        return pd.Series(result, name=self.series.name, index=self.series.index)
-
     def to(
         self,
-        unit: ut.UnitLike,
-        equivalencies: list[tuple[ut.UnitLike, ut.UnitLike, Callable]] | None = None,
+        unit: "ut.UnitLike",
+        equivalencies: "list[tuple[ut.UnitLike, ut.UnitLike, Callable]] | None" = None,
     ) -> pd.Series:
         """
         Convert series to another unit.
@@ -782,7 +820,7 @@ class UnitsSeriesAccessor:
         Series
             A new converted series.
         """
-        new_array: UnitsExtensionArray = self._array.to(unit, equivalencies)
+        new_array: QuantityExtensionArray = self._array.to(unit, equivalencies)
         return self._wrap(new_array)
 
     def to_quantity(self) -> u.Quantity:
@@ -806,41 +844,17 @@ class UnitsSeriesAccessor:
             A new converted series.
         """
         q: u.Quantity = self.to_quantity()
-        new_array: UnitsExtensionArray = UnitsExtensionArray(q.si)
+        new_array: QuantityExtensionArray = QuantityExtensionArray(q.si)
         return self._wrap(new_array)
 
 
-# TODO: Add more useful methods for multi-column conversion?
-@register_dataframe_accessor("units")
-class UnitsDataFrameAccessor:
-    """
-    Accessor adding unit functionality to data frames.
-
-    Parameters
-    ----------
-    df : DataFrame
-        The dataframe the accessor methods are applied on.
-    """
-
-    df: pd.DataFrame
-
-    def __init__(self, df: pd.DataFrame) -> None:
-        self.df = df
-
-    def to_si(self) -> pd.DataFrame:
-        """
-        Convert all columns that are of unit type to SI.
-
-        Returns
-        -------
-        DataFrame
-            A new converted DataFrame.
-        """
-
-        def _f(col):
-            try:
-                return col.units.to_si()
-            except AttributeError:
-                return col
-
-        return self.df.apply(_f)
+register_astropy_type(
+    AstropyTypeSpec(
+        selector="quantity",
+        native_type=u.Quantity,
+        dtype_cls=QuantityDtype,
+        array_cls=QuantityExtensionArray,
+        series_accessor_cls=QuantitySeriesAccessor,
+        parse_params=QuantityDtype._parse_params,
+    )
+)

--- a/src/pandas_units_extension/quantity.py
+++ b/src/pandas_units_extension/quantity.py
@@ -117,7 +117,7 @@ class QuantityDtype(AstropyDtype):
                 unit = u.Unit(params)
         return cls(unit)  # type: ignore[arg-type]
 
-    def construct_array_type(self) -> type[ExtensionArray]:
+    def construct_array_type(self) -> "type[ExtensionArray]":
         return QuantityExtensionArray
 
     @property

--- a/src/pandas_units_extension/quantity.py
+++ b/src/pandas_units_extension/quantity.py
@@ -85,15 +85,18 @@ class QuantityDtype(AstropyDtype):
     _is_numeric: bool = False
     _metadata: tuple[str] = ("unit",)
 
+    # The type selector used in the dtype grammar (``astropy{<_selector>}[...]``).
+    _selector: str = "quantity"
+
     unit: UnitInstance | None
 
     def __init__(self, unit: UnitInstance | None = None) -> None:
         self.unit = unit
 
-    @staticmethod
-    def _parse_params(params: str | None) -> "QuantityDtype":
+    @classmethod
+    def _parse_params(cls, params: str | None) -> "QuantityDtype":
         """
-        Build a ``QuantityDtype`` from the ``[params]`` part of a dtype string.
+        Build a dtype from the ``[params]`` part of a dtype string.
 
         Parameters
         ----------
@@ -104,13 +107,15 @@ class QuantityDtype(AstropyDtype):
         Returns
         -------
         QuantityDtype
+            An instance of ``cls`` (so subclasses like ``AngleDtype`` build
+            themselves and apply their own unit validation).
         """
         if params is None:
             unit = None
         else:
             with u.imperial.enable():
                 unit = u.Unit(params)
-        return QuantityDtype(unit)  # type: ignore[arg-type]
+        return cls(unit)  # type: ignore[arg-type]
 
     def construct_array_type(self) -> type[ExtensionArray]:
         return QuantityExtensionArray
@@ -118,8 +123,8 @@ class QuantityDtype(AstropyDtype):
     @property
     def name(self) -> str:
         if self.unit is None:
-            return "astropy{quantity}"
-        return f"astropy{{quantity}}[{self.unit.to_string()}]"
+            return f"astropy{{{self._selector}}}"
+        return f"astropy{{{self._selector}}}[{self.unit.to_string()}]"
 
     @property
     def na_value(self) -> u.Quantity:
@@ -275,6 +280,19 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
     <Quantity [1000., 2000., 3000.] mm>
     """
 
+    # The dtype class this array uses; subclasses override to attach their own dtype.
+    _dtype_cls: "type[QuantityDtype]" = QuantityDtype
+
+    def _wrap_result(self, quantity: u.Quantity) -> "QuantityExtensionArray":
+        """
+        Wrap a result quantity back into an extension array.
+
+        The base implementation preserves the array's own type. Subclasses (e.g.
+        ``AngleExtensionArray``) override this to degrade to a more general type
+        when the result leaves their physical domain (e.g. ``angle / angle``).
+        """
+        return type(self)(quantity)
+
     # Adapted from MaskedArray to create new objects of QuantityExtensionArray for views and slices
     @classmethod
     def _simple_new(
@@ -331,7 +349,7 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
                     "Could not convert units in initialization of QuantityExtensionArray: "
                 ) from e
 
-        self._dtype: QuantityDtype = QuantityDtype(q.unit)
+        self._dtype: QuantityDtype = self._dtype_cls(q.unit)
         self._value: np.ndarray[np.float64] = q.value.astype(float)
 
     @property
@@ -435,7 +453,7 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
         # Note: copy is ignored as we always convert the strings
         values: list[u.Quantity] = [u.Quantity(s) for s in strings]
         unit: UnitInstance = dtype.unit if dtype else None
-        return QuantityExtensionArray(values, unit)
+        return cls(values, unit)
 
     @classmethod
     def _from_scalars(cls, scalars, *, dtype=None) -> "QuantityExtensionArray":
@@ -523,7 +541,7 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
         """
         q: u.Quantity = self.to_quantity()
         new_data: u.Quantity = convert(q, new_unit, equivalencies)
-        return QuantityExtensionArray(new_data)
+        return self._wrap_result(new_data)
 
     def astype(self, dtype, copy: bool = True):
         def _as_units_dtype(unit: UnitInstance) -> "QuantityExtensionArray":
@@ -616,19 +634,19 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
         values = take(
             self._value, indices, allow_fill=allow_fill, fill_value=fill_value
         )
-        return QuantityExtensionArray._simple_new(values, self._dtype)
+        return self._simple_new(values, self._dtype)
 
     @classmethod
     def _concat_same_type(cls, to_concat) -> "QuantityExtensionArray":
         if len(to_concat) == 0:
-            return QuantityExtensionArray([])
+            return cls([])
         elif len(to_concat) == 1:
             return to_concat[0]
         elif len(set(item._unit for item in to_concat)) != 1:
             # This actually never happens but left here for completeness.
             raise ValueError("Not all concatenated arrays have the same units.")
         else:
-            return QuantityExtensionArray(
+            return cls(
                 np.concatenate([item._value for item in to_concat]), to_concat[0]._unit
             )
 
@@ -661,8 +679,8 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
 
             if is_divmod:
                 # divmod returns a tuple of results
-                return cls(result_q[0]), cls(result_q[1])
-            return cls(result_q)
+                return self._wrap_result(result_q[0]), self._wrap_result(result_q[1])
+            return self._wrap_result(result_q)
 
         return set_function_name(_binop, op_name, cls)
 
@@ -698,7 +716,7 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
         return set_function_name(_binop, op_name, cls)
 
     def copy(self) -> "QuantityExtensionArray":
-        return QuantityExtensionArray._simple_new(self._value.copy(), self.dtype)
+        return self._simple_new(self._value.copy(), self.dtype)
 
     def _reduce(
         self, name: str, skipna: bool = True, keepdims: bool = False, **kwargs
@@ -746,12 +764,12 @@ class QuantityExtensionArray(AstropyExtensionArray, ExtensionScalarOpsMixin):
 
     @classmethod
     def _from_factorized(cls, values, original) -> "QuantityExtensionArray":
-        return QuantityExtensionArray(values, original.dtype.unit)
+        return cls(values, original.dtype.unit)
 
     def value_counts(self, dropna=True) -> pd.Series:
         # Units preserved in the result index
         result = pd.Index(self._value).value_counts(dropna=dropna)
-        result_index = QuantityExtensionArray(result.index, self.dtype.unit)
+        result_index = type(self)(result.index, self.dtype.unit)
         result.index = result_index
         return result
 

--- a/src/pandas_units_extension/registry.py
+++ b/src/pandas_units_extension/registry.py
@@ -132,8 +132,10 @@ def infer_from_object(obj: object) -> AstropyTypeSpec | None:
     Returns
     -------
     AstropyTypeSpec or None
-        The first registered spec whose ``native_type`` is a superclass of
-        ``type(obj)``, or ``None`` if none match.
+        The registered spec with the *most specific* ``native_type`` that
+        ``obj`` is an instance of, or ``None`` if none match. Most-specific
+        (rather than first-registered) so that a subclass like ``Angle`` resolves
+        to its own spec rather than the ``Quantity`` one it also matches.
 
     Examples
     --------
@@ -144,7 +146,24 @@ def infer_from_object(obj: object) -> AstropyTypeSpec | None:
     >>> infer_from_object(42) is None
     True
     """
-    return next((spec for spec in _SPECS if isinstance(obj, spec.native_type)), None)
+    matches = [spec for spec in _SPECS if isinstance(obj, spec.native_type)]
+    return _most_specific(matches, "native_type")
+
+
+def _most_specific(matches: list[AstropyTypeSpec], attr: str) -> AstropyTypeSpec | None:
+    """
+    Pick the spec whose ``attr`` class is the most derived among ``matches``.
+
+    Assumes the matching classes form a subclass chain (as astropy's
+    ``Quantity`` -> ``Angle`` -> ``Latitude`` do); returns ``None`` for no matches.
+    """
+    if not matches:
+        return None
+    best = matches[0]
+    for spec in matches[1:]:
+        if issubclass(getattr(spec, attr), getattr(best, attr)):
+            best = spec
+    return best
 
 
 def infer_from_params(params: str) -> "AstropyDtype | None":
@@ -194,8 +213,9 @@ def infer_from_array(arr: "ExtensionArray") -> AstropyTypeSpec | None:
     Returns
     -------
     AstropyTypeSpec or None
-        The first registered spec whose ``array_cls`` ``arr`` is an instance of,
-        or ``None`` if none match.
+        The registered spec with the *most specific* ``array_cls`` that ``arr``
+        is an instance of, or ``None`` if none match (so an
+        ``AngleExtensionArray`` resolves to ``angle``, not ``quantity``).
 
     Examples
     --------
@@ -205,4 +225,5 @@ def infer_from_array(arr: "ExtensionArray") -> AstropyTypeSpec | None:
     >>> infer_from_array(QuantityExtensionArray([1, 2, 3], u.m)).selector
     'quantity'
     """
-    return next((spec for spec in _SPECS if isinstance(arr, spec.array_cls)), None)
+    matches = [spec for spec in _SPECS if isinstance(arr, spec.array_cls)]
+    return _most_specific(matches, "array_cls")

--- a/src/pandas_units_extension/registry.py
+++ b/src/pandas_units_extension/registry.py
@@ -1,0 +1,208 @@
+"""
+Registry mapping astropy types to their pandas extension implementations.
+
+A single :class:`AstropyTypeSpec` describes one astropy-backed extension type
+(e.g. a :class:`~astropy.units.Quantity`) and ties together the selector
+keyword used in the dtype grammar, the native astropy type, and the concrete
+pandas dtype/array/accessor classes. The registry powers three surfaces:
+
+- dtype-string parsing (``astropy{quantity}[...]`` -> the concrete dtype),
+- native-object ingest (:func:`~pandas_units_extension.base.from_astropy`),
+- accessor dispatch (``series.astropy`` -> the right accessor subclass).
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from pandas.api.extensions import ExtensionArray
+
+    from .base import AstropyDtype, AstropyExtensionArray
+
+
+@dataclass(frozen=True, slots=True)
+class AstropyTypeSpec:
+    """
+    Description of one astropy-backed extension type.
+
+    Attributes
+    ----------
+    selector : str
+        The keyword used in the dtype grammar, e.g. ``"quantity"``.
+    native_type : type
+        The native astropy type this spec handles, e.g. ``astropy.units.Quantity``.
+    dtype_cls : type
+        The concrete :class:`AstropyDtype` subclass, e.g. ``QuantityDtype``.
+    array_cls : type
+        The concrete :class:`AstropyExtensionArray` subclass, e.g.
+        ``QuantityExtensionArray``.
+    series_accessor_cls : type or None
+        The concrete ``AstropySeriesAccessor`` subclass surfaced as
+        ``series.astropy`` for this type, or ``None`` if the type only supports
+        the common accessor methods.
+    parse_params : Callable[[str | None], AstropyDtype]
+        Build a concrete dtype instance from the ``[params]`` part of a dtype
+        string (``None`` when no brackets were given), e.g.
+        ``"km/s" -> QuantityDtype(u.Unit("km/s"))``.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension.registry import get_by_selector
+    >>> spec = get_by_selector("quantity")
+    >>> spec.selector
+    'quantity'
+    >>> spec.native_type is u.Quantity
+    True
+    >>> spec.array_cls.__name__
+    'QuantityExtensionArray'
+    """
+
+    selector: str
+    native_type: type
+    dtype_cls: type["AstropyDtype"]
+    array_cls: type["AstropyExtensionArray"]
+    series_accessor_cls: type | None
+    parse_params: Callable[[str | None], "AstropyDtype"]
+
+
+# Registration order is preserved so that inference is deterministic.
+_SPECS: list[AstropyTypeSpec] = []
+_BY_SELECTOR: dict[str, AstropyTypeSpec] = {}
+
+
+def register_astropy_type(spec: AstropyTypeSpec) -> None:
+    """
+    Register an astropy-backed extension type.
+
+    Parameters
+    ----------
+    spec : AstropyTypeSpec
+        The specification to register.
+
+    Raises
+    ------
+    ValueError
+        If a spec with the same selector is already registered.
+    """
+    if spec.selector in _BY_SELECTOR:
+        raise ValueError(
+            f"An astropy type with selector '{spec.selector}' is already registered."
+        )
+    _SPECS.append(spec)
+    _BY_SELECTOR[spec.selector] = spec
+
+
+def get_by_selector(selector: str) -> AstropyTypeSpec:
+    """
+    Look up a spec by its selector keyword.
+
+    Parameters
+    ----------
+    selector : str
+        The selector keyword, e.g. ``"quantity"``.
+
+    Returns
+    -------
+    AstropyTypeSpec
+
+    Raises
+    ------
+    KeyError
+        If no spec with the given selector is registered.
+
+    Examples
+    --------
+    >>> from pandas_units_extension.registry import get_by_selector
+    >>> get_by_selector("quantity").selector
+    'quantity'
+    """
+    return _BY_SELECTOR[selector]
+
+
+def infer_from_object(obj: object) -> AstropyTypeSpec | None:
+    """
+    Find the spec whose native type matches a native astropy object.
+
+    Parameters
+    ----------
+    obj : object
+        A native astropy object (e.g. a ``Quantity``).
+
+    Returns
+    -------
+    AstropyTypeSpec or None
+        The first registered spec whose ``native_type`` is a superclass of
+        ``type(obj)``, or ``None`` if none match.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension.registry import infer_from_object
+    >>> infer_from_object(1 * u.m).selector
+    'quantity'
+    >>> infer_from_object(42) is None
+    True
+    """
+    return next((spec for spec in _SPECS if isinstance(obj, spec.native_type)), None)
+
+
+def infer_from_params(params: str) -> "AstropyDtype | None":
+    """
+    Build a concrete dtype from the ``[params]`` of a selector-less dtype string.
+
+    Used for the ``astropy[<params>]`` form: the concrete type is inferred by
+    trying each registered type's ``parse_params`` in registration order and
+    returning the dtype produced by the first one that accepts ``params``.
+
+    Parameters
+    ----------
+    params : str
+        The parameter string from inside the square brackets, e.g. ``"km/s"``.
+
+    Returns
+    -------
+    AstropyDtype or None
+        The concrete dtype from the first type that parses ``params``, or
+        ``None`` if no registered type accepts them.
+
+    Examples
+    --------
+    >>> from pandas_units_extension.registry import infer_from_params
+    >>> infer_from_params("km/s")
+    QuantityDtype("km / s")
+    >>> infer_from_params("definitely not a unit") is None
+    True
+    """
+    for spec in _SPECS:
+        try:
+            return spec.parse_params(params)
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+def infer_from_array(arr: "ExtensionArray") -> AstropyTypeSpec | None:
+    """
+    Find the spec whose array class matches an extension array.
+
+    Parameters
+    ----------
+    arr : ExtensionArray
+        A pandas extension array.
+
+    Returns
+    -------
+    AstropyTypeSpec or None
+        The first registered spec whose ``array_cls`` ``arr`` is an instance of,
+        or ``None`` if none match.
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> from pandas_units_extension import QuantityExtensionArray
+    >>> from pandas_units_extension.registry import infer_from_array
+    >>> infer_from_array(QuantityExtensionArray([1, 2, 3], u.m)).selector
+    'quantity'
+    """
+    return next((spec for spec in _SPECS if isinstance(arr, spec.array_cls)), None)

--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -1,0 +1,167 @@
+"""Tests for the ``angle`` astropy type (astropy.coordinates.Angle support)."""
+
+import astropy.units as u
+import pandas as pd
+import pytest
+from astropy.coordinates import Angle
+
+from pandas_units_extension import (
+    AngleDtype,
+    AngleExtensionArray,
+    AngleSeriesAccessor,
+    QuantityExtensionArray,
+    from_astropy,
+)
+from pandas_units_extension.registry import infer_from_array, infer_from_object
+
+
+class TestAngleDtype:
+    def test_name(self):
+        assert AngleDtype(u.deg).name == "astropy{angle}[deg]"
+        assert AngleDtype().name == "astropy{angle}"
+
+    def test_repr(self):
+        assert repr(AngleDtype(u.deg)) == 'AngleDtype("deg")'
+
+    def test_requires_angular_unit(self):
+        with pytest.raises(ValueError, match="requires an angular unit"):
+            AngleDtype(u.m)
+
+    @pytest.mark.parametrize("unit", [u.deg, u.rad, u.arcsec, u.hourangle])
+    def test_accepts_angular_units(self, unit):
+        assert AngleDtype(unit).unit == unit
+
+    def test_construct_from_string(self):
+        from pandas_units_extension import AstropyDtype
+
+        dtype = AstropyDtype.construct_from_string("astropy{angle}[deg]")
+        assert isinstance(dtype, AngleDtype)
+        assert dtype.unit == u.deg
+
+    def test_construct_from_string_non_angular_raises(self):
+        from pandas_units_extension import AstropyDtype
+
+        with pytest.raises(ValueError, match="requires an angular unit"):
+            AstropyDtype.construct_from_string("astropy{angle}[m]")
+
+
+class TestAngleInference:
+    def test_object_inference_prefers_angle(self):
+        # Angle is a Quantity subclass; the most-specific spec must win.
+        assert infer_from_object(Angle(1, "deg")).selector == "angle"
+        assert infer_from_object(1 * u.deg).selector == "quantity"
+
+    def test_array_inference_prefers_angle(self):
+        assert infer_from_array(AngleExtensionArray([1, 2], u.deg)).selector == "angle"
+        assert (
+            infer_from_array(QuantityExtensionArray([1, 2], u.deg)).selector
+            == "quantity"
+        )
+
+    def test_series_infers_angle_from_data(self):
+        s = pd.Series([Angle(1, "deg"), Angle(2, "deg")], dtype="astropy")
+        assert isinstance(s.array, AngleExtensionArray)
+
+    def test_from_astropy(self):
+        arr = from_astropy(Angle([1, 2, 3], "deg"))
+        assert isinstance(arr, AngleExtensionArray)
+        assert arr._unit == u.deg
+
+    def test_selectorless_params_stays_quantity(self):
+        # "astropy[deg]" infers by params in registration order -> the base type.
+        from pandas_units_extension import AstropyDtype
+
+        dtype = AstropyDtype.construct_from_string("astropy[deg]")
+        assert type(dtype).__name__ == "QuantityDtype"
+
+
+class TestAngleArray:
+    def test_series_construction(self):
+        s = pd.Series([350, 10, 190], dtype="astropy{angle}[deg]")
+        assert isinstance(s.array, AngleExtensionArray)
+        assert s.dtype.unit == u.deg
+
+    def test_to_astropy_returns_angle(self):
+        s = pd.Series([1, 2, 3], dtype="astropy{angle}[deg]")
+        result = s.astropy.to_astropy()
+        assert isinstance(result, Angle)
+        assert (result == Angle([1, 2, 3], u.deg)).all()
+
+    def test_slice_and_copy_preserve_type(self):
+        arr = AngleExtensionArray([1, 2, 3], u.deg)
+        assert isinstance(arr[:2], AngleExtensionArray)
+        assert isinstance(arr.copy(), AngleExtensionArray)
+        assert isinstance(arr.take([0, 2]), AngleExtensionArray)
+
+    def test_to_preserves_angle(self):
+        s = pd.Series([1], dtype="astropy{angle}[deg]")
+        assert isinstance(s.astropy.to("arcsec").array, AngleExtensionArray)
+
+    def test_addition_stays_angle(self):
+        s = pd.Series([10, 20], dtype="astropy{angle}[deg]")
+        assert isinstance((s + s).array, AngleExtensionArray)
+
+    def test_ratio_degrades_to_quantity(self):
+        s = pd.Series([10, 20], dtype="astropy{angle}[deg]")
+        result = (s / s).array
+        assert isinstance(result, QuantityExtensionArray)
+        assert not isinstance(result, AngleExtensionArray)
+
+    def test_product_degrades_to_quantity(self):
+        s = pd.Series([10, 20], dtype="astropy{angle}[deg]")
+        assert not isinstance((s * s).array, AngleExtensionArray)
+
+
+class TestAngleAccessor:
+    def test_dispatches_to_angle_accessor(self):
+        s = pd.Series([1, 2, 3], dtype="astropy{angle}[deg]")
+        assert isinstance(s.astropy, AngleSeriesAccessor)
+
+    def test_wrap_at(self):
+        s = pd.Series([350, 10, 190], dtype="astropy{angle}[deg]")
+        result = s.astropy.wrap_at(180 * u.deg)
+        expected = pd.Series([-10, 10, -170], dtype="astropy{angle}[deg]")
+        pd.testing.assert_series_equal(result, expected)
+
+    def test_wrap_at_returns_angle_backed_series(self):
+        s = pd.Series([350], dtype="astropy{angle}[deg]")
+        assert isinstance(s.astropy.wrap_at(180 * u.deg).array, AngleExtensionArray)
+
+    def test_dms(self):
+        s = pd.Series([10.5], dtype="astropy{angle}[deg]")
+        result = s.astropy.dms
+        assert list(result.columns) == ["d", "m", "s"]
+        assert result.loc[0, "d"] == 10.0
+        assert result.loc[0, "m"] == 30.0
+
+    def test_hms(self):
+        s = pd.Series([180], dtype="astropy{angle}[deg]")
+        result = s.astropy.hms
+        assert list(result.columns) == ["h", "m", "s"]
+        assert result.loc[0, "h"] == 12.0
+
+    def test_signed_dms(self):
+        s = pd.Series([-20.25], dtype="astropy{angle}[deg]")
+        result = s.astropy.signed_dms
+        assert list(result.columns) == ["sign", "d", "m", "s"]
+        assert result.loc[0, "sign"] == -1.0
+        assert result.loc[0, "d"] == 20.0
+
+    def test_dms_aligns_index(self):
+        s = pd.Series([10.5, 20.5], index=["a", "b"], dtype="astropy{angle}[deg]")
+        assert list(s.astropy.dms.index) == ["a", "b"]
+
+    def test_is_within_bounds(self):
+        s = pd.Series([10, 20, 30], dtype="astropy{angle}[deg]")
+        assert s.astropy.is_within_bounds(0 * u.deg, 90 * u.deg) is True
+        assert s.astropy.is_within_bounds(0 * u.deg, 15 * u.deg) is False
+
+    def test_inherited_quantity_methods(self):
+        s = pd.Series([1], dtype="astropy{angle}[deg]")
+        assert s.astropy.unit == u.deg
+        assert isinstance(s.astropy.to_astropy(), Angle)
+
+    def test_quantity_series_has_no_angle_methods(self):
+        # wrap_at must be absent on a plain quantity-backed Series.
+        s = pd.Series([1, 2, 3], dtype="astropy{quantity}[m]")
+        assert not hasattr(s.astropy, "wrap_at")

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -1,0 +1,237 @@
+"""Tests for the ``astropy`` framework: grammar, registry, dispatch and ingest."""
+
+import astropy.units as u
+import numpy as np
+import pandas as pd
+import pytest
+from astropy.table import QTable
+
+from pandas_units_extension import (
+    AstropyDtype,
+    QuantityDtype,
+    QuantityExtensionArray,
+    QuantitySeriesAccessor,
+    from_astropy,
+)
+from pandas_units_extension._grammar import ParsedDtype, parse_dtype_string
+from pandas_units_extension.registry import (
+    get_by_selector,
+    infer_from_array,
+    infer_from_object,
+    infer_from_params,
+)
+
+
+class TestGrammar:
+    @pytest.mark.parametrize(
+        ("string", "expected"),
+        [
+            ("astropy", ParsedDtype(None, None)),
+            ("astropy{quantity}", ParsedDtype("quantity", None)),
+            ("astropy{quantity}[km/s]", ParsedDtype("quantity", "km/s")),
+            ("astropy{quantity}[]", ParsedDtype("quantity", "")),
+            ("astropy[km/s]", ParsedDtype(None, "km/s")),
+            ("astropy[]", ParsedDtype(None, "")),
+            (
+                "astropy{representation}[cartesian]",
+                ParsedDtype("representation", "cartesian"),
+            ),
+        ],
+    )
+    def test_parses(self, string, expected):
+        assert parse_dtype_string(string) == expected
+
+    @pytest.mark.parametrize(
+        "string", ["astropy{}", "unit", "float64", "astropy_quantity"]
+    )
+    def test_invalid_raises(self, string):
+        with pytest.raises(TypeError):
+            parse_dtype_string(string)
+
+    def test_non_string_raises(self):
+        with pytest.raises(TypeError):
+            parse_dtype_string(0)  # type: ignore[arg-type]
+
+
+class TestRegistry:
+    def test_get_by_selector(self):
+        spec = get_by_selector("quantity")
+        assert spec.native_type is u.Quantity
+        assert spec.array_cls is QuantityExtensionArray
+        assert spec.dtype_cls is QuantityDtype
+
+    def test_get_by_selector_unknown(self):
+        with pytest.raises(KeyError):
+            get_by_selector("nope")
+
+    def test_infer_from_object(self):
+        assert infer_from_object(1 * u.m).selector == "quantity"
+        assert infer_from_object(u.Quantity([1, 2], "m")).selector == "quantity"
+
+    def test_infer_from_object_no_match(self):
+        assert infer_from_object(1.0) is None
+        assert infer_from_object("1 m") is None
+
+    def test_infer_from_array(self):
+        arr = QuantityExtensionArray([1, 2, 3], u.m)
+        assert infer_from_array(arr).selector == "quantity"
+
+    def test_infer_from_array_no_match(self):
+        assert infer_from_array(pd.array([1, 2, 3])) is None
+
+    def test_infer_from_params(self):
+        dtype = infer_from_params("km/s")
+        assert isinstance(dtype, QuantityDtype)
+        assert dtype.unit == u.km / u.s
+
+    def test_infer_from_params_no_match(self):
+        assert infer_from_params("definitely not a unit") is None
+
+
+class TestDtypeConstruction:
+    @pytest.mark.parametrize(
+        ("string", "unit"),
+        [
+            ("astropy{quantity}[m]", u.m),
+            ("astropy{quantity}[km/s]", u.km / u.s),
+            ("astropy{quantity}[]", u.Unit("")),
+        ],
+    )
+    def test_typed_string(self, string, unit):
+        dtype = AstropyDtype.construct_from_string(string)
+        assert isinstance(dtype, QuantityDtype)
+        assert dtype.unit == unit
+
+    @pytest.mark.parametrize(
+        ("string", "unit"),
+        [
+            ("astropy[m]", u.m),
+            ("astropy[km/s]", u.km / u.s),
+            ("astropy[]", u.Unit("")),
+        ],
+    )
+    def test_selectorless_params_string(self, string, unit):
+        # "astropy[...]" infers the concrete type from the parameters.
+        dtype = AstropyDtype.construct_from_string(string)
+        assert isinstance(dtype, QuantityDtype)
+        assert dtype.unit == unit
+
+    def test_selectorless_params_unparseable_raises(self):
+        with pytest.raises(TypeError, match="Cannot infer an astropy type"):
+            AstropyDtype.construct_from_string("astropy[definitely not a unit]")
+
+    def test_bare_quantity_string(self):
+        dtype = AstropyDtype.construct_from_string("astropy{quantity}")
+        assert isinstance(dtype, QuantityDtype)
+        assert dtype.unit is None
+
+    def test_bare_astropy_string(self):
+        dtype = AstropyDtype.construct_from_string("astropy")
+        assert type(dtype) is AstropyDtype
+        assert dtype.name == "astropy"
+
+    def test_unknown_selector_raises(self):
+        with pytest.raises(TypeError, match="Unknown astropy type selector"):
+            AstropyDtype.construct_from_string("astropy{nope}")
+
+    def test_name_roundtrip(self):
+        dtype = QuantityDtype(u.m**2)
+        assert dtype.name == "astropy{quantity}[m2]"
+        assert QuantityDtype.construct_from_string(dtype.name) == dtype
+
+    def test_repr(self):
+        assert repr(QuantityDtype()) == "QuantityDtype()"
+        assert repr(QuantityDtype(u.m)) == 'QuantityDtype("m")'
+
+
+class TestIngest:
+    def test_series_typed(self):
+        s = pd.Series([1, 2, 3], dtype="astropy{quantity}[km/s]")
+        assert isinstance(s.array, QuantityExtensionArray)
+        assert s.dtype.unit == u.km / u.s
+
+    def test_series_selectorless_params(self):
+        s = pd.Series([1, 2, 3], dtype="astropy[km/s]")
+        assert isinstance(s.array, QuantityExtensionArray)
+        assert s.dtype.unit == u.km / u.s
+
+    def test_series_bare_infers_from_quantity(self):
+        s = pd.Series([1 * u.m, 2 * u.m], dtype="astropy")
+        assert isinstance(s.array, QuantityExtensionArray)
+        assert s.dtype.unit == u.m
+
+    def test_series_bare_from_quantity_object(self):
+        s = pd.Series(u.Quantity([1, 2, 3], "m"), dtype="astropy")
+        assert s.dtype.unit == u.m
+
+    def test_series_bare_without_type_info_raises(self):
+        with pytest.raises(TypeError, match="Cannot infer astropy type"):
+            pd.Series([1.0, 2.0], dtype="astropy")
+
+    def test_pd_array_with_dtype(self):
+        arr = pd.array([1 * u.m, 2 * u.m], dtype="astropy")
+        assert isinstance(arr, QuantityExtensionArray)
+        assert arr._unit == u.m
+
+    def test_from_astropy(self):
+        arr = from_astropy(u.Quantity([1, 2, 3], "m"))
+        assert isinstance(arr, QuantityExtensionArray)
+        assert arr._unit == u.m
+
+    def test_from_astropy_unsupported(self):
+        with pytest.raises(TypeError, match="No registered astropy extension type"):
+            from_astropy("not an astropy object")
+
+
+class TestSeriesAccessor:
+    def test_dispatches_to_quantity_accessor(self):
+        s = pd.Series([1, 2, 3], dtype="astropy{quantity}[m]")
+        assert isinstance(s.astropy, QuantitySeriesAccessor)
+
+    def test_to_astropy(self):
+        s = pd.Series([1, 2, 3], dtype="astropy{quantity}[m]")
+        result = s.astropy.to_astropy()
+        assert isinstance(result, u.Quantity)
+        assert (result == u.Quantity([1, 2, 3], u.m)).all()
+
+    def test_plain_series_has_no_accessor(self):
+        with pytest.raises(AttributeError):
+            _ = pd.Series([1, 2, 3]).astropy
+
+
+class TestDataFrameAccessor:
+    def test_to_table_preserves_units(self):
+        df = pd.DataFrame(
+            {
+                "a": pd.Series([1, 2, 3], dtype="astropy{quantity}[km]"),
+                "b": pd.Series([4, 5, 6], dtype="astropy{quantity}[s]"),
+            }
+        )
+        table = df.astropy.to_table()
+        assert isinstance(table, QTable)
+        assert table["a"].unit == u.km
+        assert table["b"].unit == u.s
+        np.testing.assert_array_equal(table["a"].value, [1, 2, 3])
+
+    def test_to_table_mixed_columns(self):
+        df = pd.DataFrame(
+            {
+                "q": pd.Series([1, 2, 3], dtype="astropy{quantity}[m]"),
+                "plain": [10, 20, 30],
+            }
+        )
+        table = df.astropy.to_table()
+        assert table["q"].unit == u.m
+        np.testing.assert_array_equal(table["plain"], [10, 20, 30])
+
+    def test_to_si_ignores_non_astropy_columns(self):
+        df = pd.DataFrame(
+            {
+                "a": pd.Series([1, 2, 3], dtype="astropy{quantity}[km]"),
+                "plain": [10, 20, 30],
+            }
+        )
+        result = df.astropy.to_si()
+        expected_a = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[m]")
+        pd.testing.assert_series_equal(result["a"], expected_a, check_names=False)
+        np.testing.assert_array_equal(result["plain"], [10, 20, 30])

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -1,5 +1,4 @@
 # ruff: disable[F401,F811]
-from __future__ import annotations
 
 import operator
 
@@ -25,11 +24,11 @@ from pandas.tests.extension.conftest import (
 
 from pandas_units_extension import (
     InvalidUnitConversionError,
-    UnitsDtype,
-    UnitsExtensionArray,
-    UnitsSeriesAccessor,
-    as_quantity,
+    QuantityDtype,
+    QuantityExtensionArray,
+    QuantitySeriesAccessor,
 )
+from pandas_units_extension.quantity import as_quantity
 
 _all_arithmetic_operators: list[str] = [
     "__add__",
@@ -87,12 +86,12 @@ def using_nan_is_na(request):
 
 @pytest.fixture
 def data():
-    return UnitsExtensionArray([1, 2] + 8 * [3], u.m)
+    return QuantityExtensionArray([1, 2] + 8 * [3], u.m)
 
 
 @pytest.fixture()
 def data_for_twos():
-    return UnitsExtensionArray([2] * 10, u.m)
+    return QuantityExtensionArray([2] * 10, u.m)
 
 
 @pytest.fixture
@@ -100,12 +99,12 @@ def data_missing():
     """
     Length-2 array with [NA, Valid].
     """
-    return UnitsExtensionArray([np.nan, 1] * u.m)
+    return QuantityExtensionArray([np.nan, 1] * u.m)
 
 
 @pytest.fixture
 def simple_data():
-    return UnitsExtensionArray([1, 2, 3], u.m)
+    return QuantityExtensionArray([1, 2, 3], u.m)
 
 
 @pytest.fixture
@@ -131,7 +130,7 @@ def all_data(request, data, data_missing):
 
 @pytest.fixture
 def dtype():
-    return UnitsDtype(u.m)
+    return QuantityDtype(u.m)
 
 
 @pytest.fixture
@@ -154,7 +153,7 @@ def na_value():
 
 @pytest.fixture
 def data_for_grouping():
-    return UnitsExtensionArray([2, 2, np.nan, np.nan, 1, 1, 2, 3], u.g)
+    return QuantityExtensionArray([2, 2, np.nan, np.nan, 1, 1, 2, 3], u.g)
 
 
 @pytest.fixture
@@ -165,7 +164,7 @@ def data_for_sorting():
     This should be three items [B, C, A] with
     A < B < C
     """
-    return UnitsExtensionArray([2, 3, 1], u.m)
+    return QuantityExtensionArray([2, 3, 1], u.m)
 
 
 @pytest.fixture
@@ -176,7 +175,7 @@ def data_missing_for_sorting():
     This should be three items [B, NA, A] with
     A < B and NA missing.
     """
-    return UnitsExtensionArray([3, np.nan, 1], u.m)
+    return QuantityExtensionArray([3, np.nan, 1], u.m)
 
 
 @pytest.fixture
@@ -224,36 +223,41 @@ class TestConstructors(base.BaseConstructorsTests):
 
 class TestCasting(base.BaseCastingTests):
     def test_compatible_conversion(self):
-        s = pd.Series([3, 4], dtype="unit[m]")
-        result = s.astype("unit[cm]")
-        expected = pd.Series([300, 400], dtype="unit[cm]")
+        s = pd.Series([3, 4], dtype="astropy{quantity}[m]")
+        result = s.astype("astropy{quantity}[cm]")
+        expected = pd.Series([300, 400], dtype="astropy{quantity}[cm]")
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("generic", [False, True])
     def test_convert_from_object(self, generic):
         s = pd.Series([2, 3] * u.m)
-        dtype = "unit" if generic else "unit[m]"
+        # Bare "astropy" works here: the object data are Quantities, so the type
+        # is inferred. String data (see test_series_from_string_list) needs the
+        # explicit "astropy{quantity}" form.
+        dtype = "astropy" if generic else "astropy{quantity}[m]"
         result = s.astype(dtype)
-        expected = pd.Series([2, 3], dtype="unit[m]")
+        expected = pd.Series([2, 3], dtype="astropy{quantity}[m]")
         tm.assert_series_equal(result, expected)
 
     def test_convert_from_timedelta(self):
         s = pd.Series(pd.timedelta_range(0, periods=3, freq="h"))
-        result = s.astype("unit")
-        expected = pd.Series([0, 3600, 7200], dtype="unit[s]")
+        result = s.astype("astropy{quantity}")
+        expected = pd.Series([0, 3600, 7200], dtype="astropy{quantity}[s]")
         tm.assert_series_equal(result, expected)
 
     def test_astype_timedelta(self):
-        s = pd.Series([0, 1, 2], dtype="unit[h]")
+        s = pd.Series([0, 1, 2], dtype="astropy{quantity}[h]")
         result = s.astype("timedelta64[ns]")
         expected = pd.Series(pd.timedelta_range(0, periods=3, freq="h"))
         tm.assert_series_equal(result, expected)
 
 
 class TestDtype(base.BaseDtypeTests):
-    @pytest.mark.parametrize(("f", "expected"), [(str, "unit"), (repr, "UnitsDtype()")])
+    @pytest.mark.parametrize(
+        ("f", "expected"), [(str, "astropy{quantity}"), (repr, "QuantityDtype()")]
+    )
     def test_str_and_repr_without_unit(self, f, expected):
-        dtype = UnitsDtype()
+        dtype = QuantityDtype()
         assert f(dtype) == expected
 
 
@@ -266,7 +270,7 @@ class TestGroupBy(base.BaseGroupbyTests):
         return super().test_groupby_agg_extension(data_for_grouping)
 
     @pytest.mark.xfail(
-        reason="The UnitsDtype is non of the dtypes for which the test expects a successful grouping, therefore no TypeError is raised",
+        reason="The QuantityDtype is non of the dtypes for which the test expects a successful grouping, therefore no TypeError is raised",
     )
     def test_in_numeric_groupby(self, data_for_grouping):
         return super().test_in_numeric_groupby(data_for_grouping)
@@ -274,10 +278,10 @@ class TestGroupBy(base.BaseGroupbyTests):
 
 class TestGetitem(base.BaseGetitemTests):
     def test_unitless(self):
-        series = pd.Series([0, 1, 2], dtype="unit[]")
+        series = pd.Series([0, 1, 2], dtype="astropy{quantity}[]")
         new_index = [2, 4]
         result = series.reindex(new_index)
-        expected = pd.Series([2, np.nan], dtype="unit[]", index=new_index)
+        expected = pd.Series([2, np.nan], dtype="astropy{quantity}[]", index=new_index)
         tm.assert_series_equal(result, expected)
 
 
@@ -287,7 +291,7 @@ class TestInterface(base.BaseInterfaceTests):
         # data_missing is of dtype unit[m] so `np.nan * u.m` should be in it
         assert (np.nan * u.m) in data_missing
 
-        # UnitsExtensionArray is flexible in regards to the unit of a na-value
+        # QuantityExtensionArray is flexible in regards to the unit of a na-value
         # for __contains__() as long as the physical type is the same (here length),
         # so `np.nan * u.cm` should also be in data_missing
         assert (np.nan * u.cm) in data_missing
@@ -298,7 +302,7 @@ class TestInterface(base.BaseInterfaceTests):
 
 class TestMethods(base.BaseMethodsTests):
     def test_searchsorted_unit_aware(self, data_for_sorting, as_series):
-        arr: UnitsExtensionArray = UnitsExtensionArray([1, 2, 3], u.m)
+        arr: QuantityExtensionArray = QuantityExtensionArray([1, 2, 3], u.m)
 
         if as_series:
             arr = pd.Series(arr)
@@ -328,11 +332,11 @@ class TestMethods(base.BaseMethodsTests):
     )
     def test_value_counts(self, dropna, expected_index, expected_values):
         # Custom test required, as the parent removes the units info
-        s = pd.Series([1, 1, 2, np.nan], dtype="unit[m]")
+        s = pd.Series([1, 1, 2, np.nan], dtype="astropy{quantity}[m]")
         result = s.value_counts(dropna=dropna)
         expected = pd.Series(
             expected_values,
-            index=UnitsExtensionArray(expected_index, unit=u.m),
+            index=QuantityExtensionArray(expected_index, unit=u.m),
             dtype="int64",
             name="count",
         )
@@ -352,7 +356,7 @@ class TestReduce(base.BaseReduceTests):
         # Besides `var` all reductions retain the same unit so same dtype.
         # However `var` returns a squared unit and the new expected dtype is calculated and returned
         if op_name in {"var"}:
-            return UnitsDtype(arr._unit**2)
+            return QuantityDtype(arr._unit**2)
         return arr.dtype
 
     def check_reduce(self, ser: pd.Series, op_name: str, skipna: bool):
@@ -412,9 +416,11 @@ class TestParsing(base.BaseParsingTests):
     @pytest.mark.parametrize("generic", [False, True])
     def test_series_from_string_list(self, generic):
         source = ["1 m", "2 m"]
-        dtype = "unit" if generic else "unit[m]"
+        # String data carries no astropy type info, so the generic form must be
+        # the explicit "astropy{quantity}" (bare "astropy" would raise).
+        dtype = "astropy{quantity}" if generic else "astropy{quantity}[m]"
         result = pd.Series(source, dtype=dtype)
-        expected = pd.Series([1, 2], dtype="unit[m]")
+        expected = pd.Series([1, 2], dtype="astropy{quantity}[m]")
         tm.assert_series_equal(result, expected)
 
 
@@ -429,7 +435,7 @@ class TestPrinting(base.BasePrintingTests):
 class TestQuantile:
     # Regression test for issue #1
     def test_returns_correct_unit(self):
-        source = pd.Series([1, 2, 3], dtype="unit[m]")
+        source = pd.Series([1, 2, 3], dtype="astropy{quantity}[m]")
         result = source.quantile(0.5)
         assert result == 2.0 * u.m
 
@@ -443,24 +449,24 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
     def test_arith_series_with_scalar_pow(self, data):
         s = pd.Series(data)
         result = s**2
-        expected = pd.Series([1, 4] + 8 * [9], dtype="unit[m^2]")
+        expected = pd.Series([1, 4] + 8 * [9], dtype="astropy{quantity}[m^2]")
         tm.assert_series_equal(result, expected)
 
         result2 = s ** (-2)
-        expected2 = pd.Series([1, 1 / 4] + 8 * [1 / 9], dtype="unit[m^(-2)]")
+        expected2 = pd.Series([1, 1 / 4] + 8 * [1 / 9], dtype="astropy{quantity}[m^(-2)]")
         tm.assert_series_equal(result2, expected2)
 
     def test_add_incompatible_units(self):
-        s1 = pd.Series([1, 2, 3, 4], dtype="unit[kg]")
-        s2 = pd.Series([3, 4, 3, 4], dtype="unit[m]")
+        s1 = pd.Series([1, 2, 3, 4], dtype="astropy{quantity}[kg]")
+        s2 = pd.Series([3, 4, 3, 4], dtype="astropy{quantity}[m]")
         with pytest.raises(u.UnitConversionError):
             s1 + s2
 
     def test_add_compatible_units(self):
-        s1 = pd.Series([1, 2, 3, 4], dtype="unit[m]")
-        s2 = pd.Series([3, 4, 3, 4], dtype="unit[km]")
+        s1 = pd.Series([1, 2, 3, 4], dtype="astropy{quantity}[m]")
+        s2 = pd.Series([3, 4, 3, 4], dtype="astropy{quantity}[km]")
 
-        expected = pd.Series([3001, 4002, 3003, 4004], dtype="unit[m]")
+        expected = pd.Series([3001, 4002, 3003, 4004], dtype="astropy{quantity}[m]")
         result = s1 + s2
         tm.assert_series_equal(expected, result)
 
@@ -473,10 +479,10 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
     @pytest.mark.parametrize(
         ("op", "expected_dtype"),
         [
-            (operator.mul, "unit[m^2]"),
-            (roperator.rmul, "unit[m^2]"),
-            (operator.truediv, "unit[]"),
-            (roperator.rtruediv, "unit[]"),
+            (operator.mul, "astropy{quantity}[m^2]"),
+            (roperator.rmul, "astropy{quantity}[m^2]"),
+            (operator.truediv, "astropy{quantity}[]"),
+            (roperator.rtruediv, "astropy{quantity}[]"),
         ],
     )
     def test_mul_div_with_unit(self, data, op, expected_dtype):
@@ -507,9 +513,9 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         return super().test_compare_scalar(data, op)
 
     def test_comparable_units(self):
-        s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
-        s2 = pd.Series([1, 2, 3], dtype="unit[km]")
-        s3 = pd.Series([1, 3, 0], dtype="unit[km]")
+        s1 = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[m]")
+        s2 = pd.Series([1, 2, 3], dtype="astropy{quantity}[km]")
+        s3 = pd.Series([1, 3, 0], dtype="astropy{quantity}[km]")
 
         assert all(s1 == s2)
 
@@ -520,12 +526,12 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "other",
         [
-            pytest.param(pd.Series([270, 270, 270], dtype="unit[K]"), id="series"),
+            pytest.param(pd.Series([270, 270, 270], dtype="astropy{quantity}[K]"), id="series"),
             pytest.param(270 * u.K, id="value"),
         ],
     )
     def test_temperature_inequality(self, other):
-        s = pd.Series([0, -10, 10], dtype="unit[deg_C]")
+        s = pd.Series([0, -10, 10], dtype="astropy{quantity}[deg_C]")
 
         result = s < other
         expected = pd.Series([False, True, False])
@@ -534,19 +540,19 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "other",
         [
-            pytest.param(pd.Series([273.15, 274, 0], dtype="unit[K]"), id="series"),
+            pytest.param(pd.Series([273.15, 274, 0], dtype="astropy{quantity}[K]"), id="series"),
             pytest.param(32 * u.imperial.deg_F, id="value"),
         ],
     )
     def test_temperature_equality(self, other):
-        s = pd.Series([0, -10, 10], dtype="unit[deg_C]")
+        s = pd.Series([0, -10, 10], dtype="astropy{quantity}[deg_C]")
         result = s == other
         expected = pd.Series([True, False, False])
         tm.assert_series_equal(expected, result)
 
     def test_incomparable_units(self, ordering_comparison_op):
-        s1 = pd.Series([1000, 2000, 3000], dtype="unit[m]")
-        s2 = pd.Series([1000, 2000, 3000], dtype="unit[s]")
+        s1 = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[m]")
+        s2 = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[s]")
 
         with pytest.raises(InvalidUnitConversionError):
             ordering_comparison_op(s1, s2)
@@ -559,7 +565,7 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
         ],
     )
     def test_with_incompatible_non_units(self, ordering_comparison_op, other):
-        s = pd.Series([1000, 2000, 3000], dtype="unit[m]")
+        s = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[m]")
         with pytest.raises(InvalidUnitConversionError):
             ordering_comparison_op(s, other)
         with pytest.raises(InvalidUnitConversionError):
@@ -574,19 +580,19 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
             pytest.param(1 * u.m, pd.Series([True, False]), id="quantity"),
             pytest.param(pd.Series([1, 2]), pd.Series([False, False]), id="series"),
             pytest.param(
-                pd.Series([100, 50], dtype="unit[cm]"),
+                pd.Series([100, 50], dtype="astropy{quantity}[cm]"),
                 pd.Series([True, False]),
                 id="series-with-compatible-unit",
             ),
             pytest.param(
-                pd.Series([1, 2], dtype="unit[kg]"),
+                pd.Series([1, 2], dtype="astropy{quantity}[kg]"),
                 pd.Series([False, False]),
                 id="series-with-incompatible-unit",
             ),
         ],
     )
     def test_eq_ne(self, other, expected_equal, equality_comparison_op):
-        s = pd.Series([1, 2], dtype="unit[m]")
+        s = pd.Series([1, 2], dtype="astropy{quantity}[m]")
         if equality_comparison_op == operator.eq:
             expected = expected_equal
         else:
@@ -598,58 +604,58 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
 class TestRepr:
     def test_repr(self, simple_data):
         expected: str = (
-            "<UnitsExtensionArray>\n[1.0 m, 2.0 m, 3.0 m]\nLength: 3, dtype: unit[m]"
+            "<QuantityExtensionArray>\n[1.0 m, 2.0 m, 3.0 m]\nLength: 3, dtype: astropy{quantity}[m]"
         )
         assert expected == repr(simple_data)
 
     def test_series_repr(self, simple_data):
-        expected: str = "0    1.0 m\n1    2.0 m\n2    3.0 m\ndtype: unit[m]"
+        expected: str = "0    1.0 m\n1    2.0 m\n2    3.0 m\ndtype: astropy{quantity}[m]"
         assert expected == repr(pd.Series(simple_data))
 
 
-class TestUnitsSeriesAccessor(BaseOpsUtil):
+class TestQuantitySeriesAccessor(BaseOpsUtil):
     def test_init(self, simple_data):
         s = pd.Series(simple_data)
-        assert isinstance(s.units, UnitsSeriesAccessor)
+        assert isinstance(s.astropy, QuantitySeriesAccessor)
 
     def test_invalid_type(self):
         s = pd.Series([1, 2, 3])
         with pytest.raises(AttributeError):
-            _ = s.units
+            _ = s.astropy
 
     def test_to(self, simple_data):
         s = pd.Series(simple_data)
-        result = s.units.to("mm")
-        expected = pd.Series([1000, 2000, 3000], dtype="unit[mm]")
+        result = s.astropy.to("mm")
+        expected = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[mm]")
         tm.assert_series_equal(result, expected)
 
     def test_to_quantity(self, simple_data):
         s = pd.Series(simple_data)
-        result = s.units.to_quantity()
+        result = s.astropy.to_quantity()
         expected = u.Quantity([1, 2, 3], u.m)
         assert isinstance(result, u.Quantity)
         assert (result == expected).all()
 
     def test_unit(self, simple_data):
         s = pd.Series(simple_data)
-        assert s.units.unit == u.m
+        assert s.astropy.unit == u.m
 
     def test_to_si(self):
-        s = pd.Series([1, 2, 3], dtype="unit[km]")
-        result = s.units.to_si()
-        expected = pd.Series([1000, 2000, 3000], dtype="unit[m]")
+        s = pd.Series([1, 2, 3], dtype="astropy{quantity}[km]")
+        result = s.astropy.to_si()
+        expected = pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[m]")
         tm.assert_series_equal(result, expected)
 
     def test_to_si_composite_unit(self):
-        s = pd.Series([1, 2, 3], dtype="unit[km/h]")
-        result = s.units.to_si()
-        expected = pd.Series([1000 / 3600, 2000 / 3600, 3000 / 3600], dtype="unit[m/s]")
+        s = pd.Series([1, 2, 3], dtype="astropy{quantity}[km/h]")
+        result = s.astropy.to_si()
+        expected = pd.Series([1000 / 3600, 2000 / 3600, 3000 / 3600], dtype="astropy{quantity}[m/s]")
         tm.assert_series_equal(result, expected)
 
     def test_temperature(self):
-        s = pd.Series([0, 100], dtype="unit[deg_C]")
-        s_f = s.units.to("deg_F")
-        s_f_expected = pd.Series([32, 212], dtype="unit[deg_F]")
+        s = pd.Series([0, 100], dtype="astropy{quantity}[deg_C]")
+        s_f = s.astropy.to("deg_F")
+        s_f_expected = pd.Series([32, 212], dtype="astropy{quantity}[deg_F]")
         tm.assert_series_equal(s_f, s_f_expected)
 
 
@@ -657,15 +663,15 @@ class TestUnitsDataFrameAccessor(BaseOpsUtil):
     def test_df_to_si(self):
         df = pd.DataFrame(
             {
-                "a": pd.Series([1, 2, 3], dtype="unit[km]"),
-                "b": pd.Series([2, 3, 4], dtype="unit[hour]"),
+                "a": pd.Series([1, 2, 3], dtype="astropy{quantity}[km]"),
+                "b": pd.Series([2, 3, 4], dtype="astropy{quantity}[hour]"),
             }
         )
-        result = df.units.to_si()
+        result = df.astropy.to_si()
         expected = pd.DataFrame(
             {
-                "a": pd.Series([1000, 2000, 3000], dtype="unit[m]"),
-                "b": pd.Series([7200, 10800, 14400], dtype="unit[s]"),
+                "a": pd.Series([1000, 2000, 3000], dtype="astropy{quantity}[m]"),
+                "b": pd.Series([7200, 10800, 14400], dtype="astropy{quantity}[s]"),
             }
         )
         tm.assert_frame_equal(result, expected)
@@ -676,11 +682,11 @@ class TestVarious(BaseExtensionTests):
         ("value", "expected"),
         [
             pytest.param(
-                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"
+                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="astropy{quantity}"), id="standard-unit"
             ),
             pytest.param(
                 1 * u.imperial.ft,
-                pd.Series(["1 m", "0.3048 m"], dtype="unit"),
+                pd.Series(["1 m", "0.3048 m"], dtype="astropy{quantity}"),
                 id="imperial-unit",
             ),
         ],
@@ -690,8 +696,8 @@ class TestVarious(BaseExtensionTests):
 
         Both units are of same physical type (length), expected values are converted to first unit, in this case meter.
         """
-        s1 = pd.Series(["1 m"], dtype="unit")
-        s2 = pd.Series([value], dtype="unit")
+        s1 = pd.Series(["1 m"], dtype="astropy{quantity}")
+        s2 = pd.Series([value], dtype="astropy{quantity}")
         concatenated = pd.concat([s1, s2]).reset_index(drop=True)
         tm.assert_series_equal(expected, concatenated)
 
@@ -700,14 +706,14 @@ class TestVarious(BaseExtensionTests):
 
         Both units are of different physical types (length vs speed), no conversion is done and dtype should be object.
         """
-        s1 = pd.Series(["1 m"], dtype="unit")
-        s2 = pd.Series(["1 m/s"], dtype="unit")
+        s1 = pd.Series(["1 m"], dtype="astropy{quantity}")
+        s2 = pd.Series(["1 m/s"], dtype="astropy{quantity}")
         concatenated = pd.concat([s1, s2]).reset_index(drop=True)
         expected = pd.Series([u.Quantity("1 m"), u.Quantity("1 m/s")], dtype=object)
         tm.assert_series_equal(expected, concatenated)
 
     def test_concat_no_unit(self):
-        s1 = pd.Series(["1 m"], dtype="unit")
+        s1 = pd.Series(["1 m"], dtype="astropy{quantity}")
         s2 = pd.Series([2, 3])
         concatenated = pd.concat([s1, s2]).reset_index(drop=True)
         expected = pd.Series([u.Quantity("1 m"), 2, 3], dtype=object)
@@ -721,17 +727,17 @@ class TestVarious(BaseExtensionTests):
         ("value", "expected"),
         [
             pytest.param(
-                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="unit"), id="standard-unit"
+                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="astropy{quantity}"), id="standard-unit"
             ),
             pytest.param(
                 1 * u.imperial.ft,
-                pd.Series(["1 m", "0.3048 m"], dtype="unit"),
+                pd.Series(["1 m", "0.3048 m"], dtype="astropy{quantity}"),
                 id="imperial-unit",
             ),
         ],
     )
     def test_add_new_value_with_different_unit(self, value, expected):
-        s1 = pd.Series(["1 m"], dtype="unit")
+        s1 = pd.Series(["1 m"], dtype="astropy{quantity}")
         s1.at[1] = value
         tm.assert_series_equal(expected, s1)
 
@@ -739,24 +745,24 @@ class TestVarious(BaseExtensionTests):
         ("value", "expected"),
         [
             pytest.param(
-                1 * u.km, pd.Series(["1000 m"], dtype="unit"), id="standard-unit"
+                1 * u.km, pd.Series(["1000 m"], dtype="astropy{quantity}"), id="standard-unit"
             ),
             pytest.param(
                 1 * u.imperial.ft,
-                pd.Series(["0.3048 m"], dtype="unit"),
+                pd.Series(["0.3048 m"], dtype="astropy{quantity}"),
                 id="imperial-unit",
             ),
         ],
     )
     def test_set_value_with_different_unit(self, value, expected):
-        s1 = pd.Series(["1 m"], dtype="unit")
+        s1 = pd.Series(["1 m"], dtype="astropy{quantity}")
         s1[0] = value
         tm.assert_series_equal(expected, s1)
 
     def test_unique(self):
-        s = pd.Series([1, np.nan, np.nan], dtype="unit[m]")
+        s = pd.Series([1, np.nan, np.nan], dtype="astropy{quantity}[m]")
         unique = s.unique()
-        expected = UnitsExtensionArray([1, np.nan], unit="m")
+        expected = QuantityExtensionArray([1, np.nan], unit="m")
         assert unique._unit == expected._unit
         np.testing.assert_equal(expected._value, unique._value)
 
@@ -765,12 +771,12 @@ class TestVarious(BaseExtensionTests):
         [
             pytest.param(1 * u.m, u.Quantity(1, u.m), id="Quantity"),
             pytest.param(
-                UnitsExtensionArray([1, 2] * u.m),
+                QuantityExtensionArray([1, 2] * u.m),
                 u.Quantity([1, 2], u.m),
-                id="UnitsExtensionArray",
+                id="QuantityExtensionArray",
             ),
             pytest.param(
-                pd.Series([1, 2], dtype="unit[m]"), u.Quantity([1, 2], u.m), id="Series"
+                pd.Series([1, 2], dtype="astropy{quantity}[m]"), u.Quantity([1, 2], u.m), id="Series"
             ),
             pytest.param(
                 pd.Series([1e9, 2e9], dtype="timedelta64[ns]"),
@@ -809,13 +815,13 @@ class TestVarious(BaseExtensionTests):
 
     def test_imperial_units_in_series(self):
         """Test that imperial units can be used in a Series."""
-        pd.Series([1, 2, 3], dtype="unit[ft]")
+        pd.Series([1, 2, 3], dtype="astropy{quantity}[ft]")
 
     def test_imperial_units_conversion(self, data):
         """Test that ExtensionArray can be converted to imperial units."""
         result = data.to("ft")
         with u.imperial.enable():
-            expected = UnitsExtensionArray(data.to_quantity().to("ft"))
+            expected = QuantityExtensionArray(data.to_quantity().to("ft"))
         tm.assert_extension_array_equal(result, expected)
 
 

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -453,7 +453,9 @@ class TestArithmeticsOps(base.BaseArithmeticOpsTests):
         tm.assert_series_equal(result, expected)
 
         result2 = s ** (-2)
-        expected2 = pd.Series([1, 1 / 4] + 8 * [1 / 9], dtype="astropy{quantity}[m^(-2)]")
+        expected2 = pd.Series(
+            [1, 1 / 4] + 8 * [1 / 9], dtype="astropy{quantity}[m^(-2)]"
+        )
         tm.assert_series_equal(result2, expected2)
 
     def test_add_incompatible_units(self):
@@ -526,7 +528,9 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "other",
         [
-            pytest.param(pd.Series([270, 270, 270], dtype="astropy{quantity}[K]"), id="series"),
+            pytest.param(
+                pd.Series([270, 270, 270], dtype="astropy{quantity}[K]"), id="series"
+            ),
             pytest.param(270 * u.K, id="value"),
         ],
     )
@@ -540,7 +544,9 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
     @pytest.mark.parametrize(
         "other",
         [
-            pytest.param(pd.Series([273.15, 274, 0], dtype="astropy{quantity}[K]"), id="series"),
+            pytest.param(
+                pd.Series([273.15, 274, 0], dtype="astropy{quantity}[K]"), id="series"
+            ),
             pytest.param(32 * u.imperial.deg_F, id="value"),
         ],
     )
@@ -603,13 +609,13 @@ class TestComparisonOps(base.BaseComparisonOpsTests):
 
 class TestRepr:
     def test_repr(self, simple_data):
-        expected: str = (
-            "<QuantityExtensionArray>\n[1.0 m, 2.0 m, 3.0 m]\nLength: 3, dtype: astropy{quantity}[m]"
-        )
+        expected: str = "<QuantityExtensionArray>\n[1.0 m, 2.0 m, 3.0 m]\nLength: 3, dtype: astropy{quantity}[m]"
         assert expected == repr(simple_data)
 
     def test_series_repr(self, simple_data):
-        expected: str = "0    1.0 m\n1    2.0 m\n2    3.0 m\ndtype: astropy{quantity}[m]"
+        expected: str = (
+            "0    1.0 m\n1    2.0 m\n2    3.0 m\ndtype: astropy{quantity}[m]"
+        )
         assert expected == repr(pd.Series(simple_data))
 
 
@@ -649,7 +655,9 @@ class TestQuantitySeriesAccessor(BaseOpsUtil):
     def test_to_si_composite_unit(self):
         s = pd.Series([1, 2, 3], dtype="astropy{quantity}[km/h]")
         result = s.astropy.to_si()
-        expected = pd.Series([1000 / 3600, 2000 / 3600, 3000 / 3600], dtype="astropy{quantity}[m/s]")
+        expected = pd.Series(
+            [1000 / 3600, 2000 / 3600, 3000 / 3600], dtype="astropy{quantity}[m/s]"
+        )
         tm.assert_series_equal(result, expected)
 
     def test_temperature(self):
@@ -682,7 +690,9 @@ class TestVarious(BaseExtensionTests):
         ("value", "expected"),
         [
             pytest.param(
-                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="astropy{quantity}"), id="standard-unit"
+                1 * u.km,
+                pd.Series(["1 m", "1000 m"], dtype="astropy{quantity}"),
+                id="standard-unit",
             ),
             pytest.param(
                 1 * u.imperial.ft,
@@ -727,7 +737,9 @@ class TestVarious(BaseExtensionTests):
         ("value", "expected"),
         [
             pytest.param(
-                1 * u.km, pd.Series(["1 m", "1000 m"], dtype="astropy{quantity}"), id="standard-unit"
+                1 * u.km,
+                pd.Series(["1 m", "1000 m"], dtype="astropy{quantity}"),
+                id="standard-unit",
             ),
             pytest.param(
                 1 * u.imperial.ft,
@@ -745,7 +757,9 @@ class TestVarious(BaseExtensionTests):
         ("value", "expected"),
         [
             pytest.param(
-                1 * u.km, pd.Series(["1000 m"], dtype="astropy{quantity}"), id="standard-unit"
+                1 * u.km,
+                pd.Series(["1000 m"], dtype="astropy{quantity}"),
+                id="standard-unit",
             ),
             pytest.param(
                 1 * u.imperial.ft,
@@ -776,7 +790,9 @@ class TestVarious(BaseExtensionTests):
                 id="QuantityExtensionArray",
             ),
             pytest.param(
-                pd.Series([1, 2], dtype="astropy{quantity}[m]"), u.Quantity([1, 2], u.m), id="Series"
+                pd.Series([1, 2], dtype="astropy{quantity}[m]"),
+                u.Quantity([1, 2], u.m),
+                id="Series",
             ),
             pytest.param(
                 pd.Series([1e9, 2e9], dtype="timedelta64[ns]"),

--- a/uv.lock
+++ b/uv.lock
@@ -222,13 +222,12 @@ wheels = [
 
 [[package]]
 name = "pandas-units-extension"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
     { name = "packaging" },
     { name = "pandas" },
-    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -242,7 +241,6 @@ requires-dist = [
     { name = "astropy", specifier = ">=5.1.1" },
     { name = "packaging", specifier = ">=22" },
     { name = "pandas", specifier = ">=3.0" },
-    { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -386,15 +384,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Turns the single `Quantity`-backed extension into an **extensible, astropy-wide framework** unified under an `astropy` umbrella dtype and accessor, and adds `Angle` as the second member. This is the "0.3 – big rename" work and is intentionally **API-breaking** (no back-compat aliases).

Closes #11
Closes #31

## The `astropy` framework (commit 1)

- **Dtype grammar** `astropy{<type>}[<params>]`:
  - `astropy{quantity}[km/s]` — explicit type + params
  - `astropy[km/s]` — selector omitted, type inferred from the params (first registered type that parses them)
  - `astropy` — bare; type inferred from the data (else a clear error)
- **Registry** mapping `selector ↔ native astropy type ↔ pandas classes`, powering dtype-string parsing, `from_astropy(obj)` ingest, and `.astropy` accessor dispatch.
- **Rename** (breaking): `unit[...]` → `astropy{quantity}[...]`; `UnitsDtype`/`UnitsExtensionArray` → `QuantityDtype`/`QuantityExtensionArray`; the `.units` accessor → `.astropy`.
- **New conversions**: polymorphic `to_astropy()`; DataFrame `df.astropy.to_table()` (uses `QTable`, so units are preserved).
- `units.py` split into `_grammar` / `registry` / `base` / `quantity` modules.
- **Minimal public API**: dropped the re-exported `Quantity`/`Unit` and the `as_quantity`/`convert` helpers from the public surface (still available internally).

```python
import pandas as pd, astropy.units as u
import pandas_units_extension  # registers dtypes + accessors

s = pd.Series([1, 2, 3], dtype="astropy{quantity}[km/s]")
s.astropy.to_astropy()          # -> Quantity
s.astropy.to_si()               # -> Series
pd.Series([1*u.m, 2*u.m], dtype="astropy")  # type inferred from data
```

## Angle support (commit 2)

- `AngleDtype` / `AngleExtensionArray` / `AngleSeriesAccessor` (`astropy{angle}[deg]`), backed by `astropy.coordinates.Angle`, subclassing the Quantity classes for maximal reuse.
- Accessor adds `wrap_at`, `dms`/`hms`/`signed_dms` (as DataFrames) and `is_within_bounds`, on top of the inherited `to_astropy` (→ `Angle`), `to`, `to_si`, `unit`.
- Angular-unit validation (`astropy{angle}[m]` errors).
- Registry inference now prefers the **most-specific** type, so an `Angle` (a `Quantity` subclass) resolves to `angle`, not `quantity`.
- `QuantityExtensionArray` made subclass-friendly (`_selector`, `_dtype_cls`, `_wrap_result`); arithmetic that leaves the angular domain (`angle/angle`, `angle²`) degrades to a plain quantity.

```python
s = pd.Series([350, 10, 190], dtype="astropy{angle}[deg]")
s.astropy.wrap_at(180 * u.deg)   # -> Series of wrapped angles
s.astropy.dms                    # -> DataFrame[d, m, s]
```

## Notes for reviewers

- **API-breaking** by design (0.3, few users); no deprecated aliases.
- The `astropy{type}[params]` grammar (with the `astropy[params]` and bare-`astropy` forms) is a slightly larger design than the `astropy_quantity` name discussed in #11 — happy to adjust the surface syntax.
- Docstring examples are executed in CI via `pytest --doctest-modules`.

## Testing

- `uv run pytest` → **709 passed**, 1 skipped, 12 xfailed (inherited `pandas.tests.extension.base` suite + framework/angle tests + doctests).
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
