### PR TITLE
ENH: Support numpy ufuncs by delegating to Quantity

### DIFF
--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -25,6 +25,10 @@ from pandas.api.indexers import check_array_indexer
 from pandas.api.types import is_array_like, is_list_like, is_scalar
 from pandas.compat import set_function_name
 from pandas.core import nanops
+from pandas.core.arraylike import (
+    dispatch_ufunc_with_out,
+    maybe_dispatch_ufunc_to_dunder_op,
+)
 from pandas.core.dtypes.generic import ABCDataFrame, ABCIndex, ABCSeries
 from pandas.core.indexers import (
     getitem_returns_view,
@@ -358,6 +362,73 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             arr.setflags(write=False)
 
         return arr
+
+    def __array_ufunc__(
+        self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any
+    ):
+        """
+        Apply a numpy ufunc by delegating the unit handling to Quantity.
+
+        UnitsExtensionArray inputs are converted to Quantities and the ufunc
+        is applied to those, so that astropy handles the unit logic
+        (e.g. np.sin of degrees). Quantity results are wrapped back into
+        a UnitsExtensionArray.
+
+        Parameters
+        ----------
+        ufunc : np.ufunc
+            The ufunc being applied, e.g. np.sin.
+        method : str
+            How it is invoked: "__call__", "reduce", "accumulate", "at", ...
+        *inputs : Any
+            The operands, self among them.
+        **kwargs : Any
+            Extra ufunc options, e.g. `out`.
+
+        Returns
+        -------
+        UnitsExtensionArray or Any
+            Quantity array results wrapped as UnitsExtensionArray; scalars,
+            booleans etc. returned as-is.
+        """
+        # Let pandas unbox Series/Index/DataFrame inputs and re-dispatch to us
+        if any(isinstance(x, (ABCSeries, ABCIndex, ABCDataFrame)) for x in inputs):
+            return NotImplemented
+
+        # Keep operator-like ufuncs (np.add, np.greater, ...) flowing through
+        # the dedicated dunder methods created by _create_arithmetic_method /
+        # _create_comparison_method, as the inherited implementation did.
+        result = maybe_dispatch_ufunc_to_dunder_op(
+            self, ufunc, method, *inputs, **kwargs
+        )
+        if result is not NotImplemented:
+            return result
+
+        if "out" in kwargs:
+            # Compute without `out`, then assign into the target
+            # (same strategy as pandas' own extension arrays).
+            return dispatch_ufunc_with_out(self, ufunc, method, *inputs, **kwargs)
+
+        if method == "at" and getattr(inputs[0], "_readonly", False):
+            # astropy cannot know about our read-only flag
+            raise ValueError("Cannot modify read-only array")
+
+        # No copy: `at` relies on the Quantity sharing memory with self
+        converted = [
+            as_quantity(x, copy=False) if isinstance(x, UnitsExtensionArray) else x
+            for x in inputs
+        ]
+        result = getattr(ufunc, method)(*converted, **kwargs)
+
+        def _wrap(res: Any) -> Any:
+            if isinstance(res, u.Quantity) and res.ndim > 0:
+                return type(self)(res)
+            return res
+
+        if isinstance(result, tuple):
+            # Some ufuncs (divmod, modf, frexp) return multiple outputs
+            return tuple(_wrap(item) for item in result)
+        return _wrap(result)
 
     def __contains__(self, item: object) -> bool | np.bool_:
         """

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -430,6 +430,12 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             return tuple(_wrap(item) for item in result)
         return _wrap(result)
 
+    def __neg__(self) -> UnitsExtensionArray:
+        return UnitsExtensionArray(-self.to_quantity())
+
+    def __pos__(self) -> UnitsExtensionArray:
+        return UnitsExtensionArray(+self.to_quantity())
+
     def __contains__(self, item: object) -> bool | np.bool_:
         """
         Return for `item in self`, supports NaN values and items of different, but convertible units.

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -430,12 +430,6 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
             return tuple(_wrap(item) for item in result)
         return _wrap(result)
 
-    def __neg__(self) -> UnitsExtensionArray:
-        return UnitsExtensionArray(-self.to_quantity())
-
-    def __pos__(self) -> UnitsExtensionArray:
-        return UnitsExtensionArray(+self.to_quantity())
-
     def __contains__(self, item: object) -> bool | np.bool_:
         """
         Return for `item in self`, supports NaN values and items of different, but convertible units.

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 import operator
 
 import astropy.units as u
-from astropy.units.quantity_helper import UFUNC_HELPERS
+from astropy.units.quantity_helper.helpers import (
+    degree_to_radian_ufuncs,
+    dimensionless_to_dimensionless_ufuncs,
+    dimensionless_to_radian_ufuncs,
+    invariant_ufuncs,
+    radian_to_degree_ufuncs,
+    radian_to_dimensionless_ufuncs,
+)
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
@@ -853,12 +860,19 @@ class TestArrayInterface:
 class TestUfuncs:
     """Tests for __array_ufunc__ delegation to Quantity (GH#48)."""
 
-    # All ufuncs astropy treats like np.sin (radians in, dimensionless out),
-    # taken from its registry so that new astropy additions get tested too.
+    # Ufunc groups taken from astropy's registry, so that new astropy
+    # additions get tested automatically. Sorted for deterministic test ids.
     ANGLE_FUNCS = sorted(
-        (uf for uf, helper in UFUNC_HELPERS.items() if helper is UFUNC_HELPERS[np.sin]),
+        radian_to_dimensionless_ufuncs
+        + degree_to_radian_ufuncs
+        + radian_to_degree_ufuncs,
         key=lambda uf: uf.__name__,
     )
+    DIMENSIONLESS_FUNCS = sorted(
+        dimensionless_to_radian_ufuncs + dimensionless_to_dimensionless_ufuncs,
+        key=lambda uf: uf.__name__,
+    )
+    INVARIANT_FUNCS = sorted(set(invariant_ufuncs), key=lambda uf: uf.__name__)
 
     @pytest.mark.parametrize("func", ANGLE_FUNCS)
     @pytest.mark.parametrize(
@@ -868,9 +882,31 @@ class TestUfuncs:
             pytest.param([0, np.pi / 6, np.pi / 4, np.pi / 3] * u.rad, id="rad"),
         ],
     )
-    def test_matches_quantity_behaviour(self, func, angles):
+    def test_angle_funcs_match_quantity_behaviour(self, func, angles):
         result = func(pd.Series(angles, dtype="unit"))
         expected = pd.Series(UnitsExtensionArray(func(angles)))
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("func", DIMENSIONLESS_FUNCS)
+    def test_dimensionless_funcs_match_quantity_behaviour(self, func):
+        # arccosh is only defined for values >= 1, the others accept (0, 1)
+        values = [1.5, 2, 3] if func is np.arccosh else [0.25, 0.5, 0.75]
+        q = values * u.dimensionless_unscaled
+        result = func(pd.Series(q, dtype="unit"))
+        expected = pd.Series(UnitsExtensionArray(func(q)))
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("func", INVARIANT_FUNCS)
+    def test_invariant_funcs_match_quantity_behaviour(self, func):
+        q = [-1.5, 0, 2.5] * u.m
+        result = func(pd.Series(q, dtype="unit"))
+        expected = pd.Series(UnitsExtensionArray(func(q)))
+        tm.assert_series_equal(result, expected)
+
+    def test_sqrt_changes_unit(self):
+        areas = pd.Series([4, 9, 16] * u.m**2, dtype="unit")
+        result = np.sqrt(areas)
+        expected = pd.Series([2, 3, 4], dtype="unit[m]")
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("func", ANGLE_FUNCS)

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import operator
 
 import astropy.units as u
+from astropy.units.quantity_helper import UFUNC_HELPERS
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
@@ -852,9 +853,14 @@ class TestArrayInterface:
 class TestUfuncs:
     """Tests for __array_ufunc__ delegation to Quantity (GH#48)."""
 
-    TRIG_FUNCS = [np.sin, np.cos, np.tan]
+    # All ufuncs astropy treats like np.sin (radians in, dimensionless out),
+    # taken from its registry so that new astropy additions get tested too.
+    ANGLE_FUNCS = sorted(
+        (uf for uf, helper in UFUNC_HELPERS.items() if helper is UFUNC_HELPERS[np.sin]),
+        key=lambda uf: uf.__name__,
+    )
 
-    @pytest.mark.parametrize("func", TRIG_FUNCS)
+    @pytest.mark.parametrize("func", ANGLE_FUNCS)
     @pytest.mark.parametrize(
         "angles",
         [
@@ -867,7 +873,7 @@ class TestUfuncs:
         expected = pd.Series(UnitsExtensionArray(func(angles)))
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("func", TRIG_FUNCS)
+    @pytest.mark.parametrize("func", ANGLE_FUNCS)
     def test_incompatible_unit_raises(self, func):
         lengths = pd.Series([1, 2] * u.m, dtype="unit")
         with pytest.raises(u.UnitsError):

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -847,3 +847,36 @@ class TestArrayInterface:
     def test_disallowed_conversions(self, data, dtype):
         with pytest.raises(ValueError):
             np.array(data, dtype=dtype, copy=False)
+
+
+class TestUfuncs:
+    """Tests for __array_ufunc__ delegation to Quantity (GH#48)."""
+
+    TRIG_FUNCS = [np.sin, np.cos, np.tan]
+
+    @pytest.mark.parametrize("func", TRIG_FUNCS)
+    @pytest.mark.parametrize(
+        "angles",
+        [
+            pytest.param([0, 30, 45, 60] * u.deg, id="deg"),
+            pytest.param([0, np.pi / 6, np.pi / 4, np.pi / 3] * u.rad, id="rad"),
+        ],
+    )
+    def test_matches_quantity_behaviour(self, func, angles):
+        result = func(pd.Series(angles, dtype="unit"))
+        expected = pd.Series(UnitsExtensionArray(func(angles)))
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("func", TRIG_FUNCS)
+    def test_incompatible_unit_raises(self, func):
+        lengths = pd.Series([1, 2] * u.m, dtype="unit")
+        with pytest.raises(u.UnitsError):
+            func(lengths)
+
+    def test_at_respects_readonly(self):
+        """np.add.at writes in place; it must respect the read-only flag."""
+        arr = pd.Series([0, 45, 90] * u.deg, dtype="unit").array
+        arr._readonly = True
+        with pytest.raises(ValueError, match="read-only"):
+            np.add.at(arr, [0], 10 * u.deg)
+        assert list(arr._value) == [0, 45, 90]


### PR DESCRIPTION
Closes #48.

Adds `UnitsExtensionArray.__array_ufunc__` so that numpy ufuncs work on Series with unit dtype:

```python
s = pd.Series([0, 45, 90, 180, 360] * u.deg, dtype="unit")
np.sin(s)   # previously TypeError, now a dimensionless Series matching np.sin(q)
```

**How it works:** `UnitsExtensionArray` inputs are converted to `Quantity` (no copy) and the ufunc is re-applied, so numpy dispatches to astropy's own `__array_ufunc__` for the unit logic (`sin(deg)` → dimensionless, `sqrt(m²)` → `m`, `sin(m)` → `UnitsError`). `Quantity` array results are wrapped back into `UnitsExtensionArray`; scalars and booleans pass through.

**Design notes:**
- Operator-like ufuncs (`np.add`, `np.greater`, ...) keep flowing through the existing dunder methods from `_create_arithmetic_method` / `_create_comparison_method`, preserving their unit-conversion and error semantics (same routing the inherited pandas implementation did).
- `out=` is supported the same way pandas' own extension arrays do it (`dispatch_ufunc_with_out`): compute, then assign into the target — which for a units target goes through `__setitem__`, converting units and respecting the read-only flag. Without this, `out=` pointing at another units array recurses infinitely.
- `ufunc.at` works in place via the shared-memory `Quantity` (unit-checked by astropy); the only check astropy can't do for us — the `_readonly` flag — is enforced explicitly.
- `reduce`/`accumulate` flow through the same delegation (`np.add.reduce` returns a scalar `Quantity`).

Tests: a deg/rad × sin/cos/tan grid comparing against raw `Quantity` behaviour, incompatible-unit error propagation, and read-only enforcement for `ufunc.at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)