### PR TITLE
CI: Add `nightly-test` CI job

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  schedule:
+    - cron: "0 3 * * 1"
 
 jobs:
   test:
@@ -32,6 +34,32 @@ jobs:
 
       - name: Install the project
         run: uv sync --all-extras --dev
+
+      - name: Run pytest
+        run: uv run pytest
+
+  nightly-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.2"
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Install nightly astropy and pandas
+        run: >-
+          uv pip install --upgrade --pre
+          --extra-index-url https://pypi.anaconda.org/astropy/simple/astropy
+          --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pandas/
+          astropy pandas
 
       - name: Run pytest
         run: uv run pytest

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -67,7 +67,7 @@ jobs:
           pandas
 
       - name: Run pytest
-        run: uv run pytest
+        run: uv run --no-sync pytest
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -54,12 +54,17 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
-      - name: Install nightly astropy and pandas
+      - name: Install nightly astropy
         run: >-
-          uv pip install --upgrade --pre
-          --extra-index-url https://pypi.anaconda.org/astropy/simple/astropy
-          --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pandas/
-          astropy pandas
+          uv pip install --pre --upgrade
+          --default-index https://pypi.anaconda.org/astropy/simple
+          astropy
+
+      - name: Install nightly pandas
+        run: >-
+          uv pip install --pre --upgrade
+          --default-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+          pandas
 
       - name: Run pytest
         run: uv run pytest


### PR DESCRIPTION
Add another ci job called `test-nightly` that tests against the nightly builds from astropy and pandas and installs pandas-units-extension directly from repo.