### PR TITLE
Fix test_rank_missing for pandas 3.0.3

### DIFF
--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -730,6 +730,9 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def _values_for_factorize(self) -> tuple[np.ndarray, Any]:
         return self._value, None
 
+    def _values_for_argsort(self) -> np.ndarray:
+        return self._value
+
     @classmethod
     def _from_factorized(cls, values, original) -> UnitsExtensionArray:
         return UnitsExtensionArray(values, original.dtype.unit)


### PR DESCRIPTION
This PR implements `_values_for_argsort()` in `units.py` to fix compatibility with pandas 3.0.3.

Fixes #58 