### PR TITLE
Fix: replace .at with .loc in test_add_new_value_with_different_unit

### DIFF
--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -736,7 +736,7 @@ class TestVarious(BaseExtensionTests):
     )
     def test_add_new_value_with_different_unit(self, value, expected):
         s1 = pd.Series(["1 m"], dtype="unit")
-        s1.at[1] = value
+        s1.loc[1] = value
         tm.assert_series_equal(expected, s1)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary of Changes
Replaces deprecated `.at` indexing with `.loc` in `test_add_new_value_with_different_unit` to avoid upcoming `FutureWarning` / `DeprecationWarning` in pandas.

## Testing
- Ran `pytest` locally on `tests/test_pandas_units_extension.py`.