### PR TITLE
Support kurt and skew reductions

### DIFF
--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -682,7 +682,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 q = q[~np.isnan(q)]
             result: u.Quantity = getattr(q, name)(**kwargs)
 
-        # Not implemented by astropy: Recycle methods from pandas to manage nans and manage the scale correctly:
+        # Not implemented by astropy: Recycle methods from pandas to manage nans and manage the units correctly:
         elif name in ("median", "sem", "skew", "kurt"):
             data = self._value
             method = getattr(nanops, "nan" + name)  # use pd.nanops.nanskew, pd.nanops.nankurt, etc

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -682,25 +682,15 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 q = q[~np.isnan(q)]
             result: u.Quantity = getattr(q, name)(**kwargs)
 
-        # Not implemented by astropy, but should be migrated to the top block of code when they do:
-        elif name == 'skew':
-            # Recycle methods from numpy and calculate Adjusted Fisher-Pearson Standardized Moment Coefficient:
-
-            mean = np.mean(self._value, **kwargs)
-            median = np.median(self._value, **kwargs)
-            standard_deviation = np.std(self._value, **kwargs)
-            result_without_dim = (3 * (mean - median)) / standard_deviation
-            result = u.Quantity(result_without_dim, u.dimensionless_unscaled)
-
-        elif name == "kurt":
-            pass
-
-        # This methods require a little ppost-processing for the nans:
-        elif name in ("median", "sem"):
+        # Not implemented by astropy: Recycle methods from pandas to manage nans and manage the scale correctly:
+        elif name in ("median", "sem", "skew", "kurt"):
             data = self._value
-            method = getattr(nanops, "nan" + name)
+            method = getattr(nanops, "nan" + name)  # use pd.nanops.nanskew, pd.nanops.nankurt, etc
             result_without_dim = method(data, skipna=skipna)
-            result = u.Quantity(result_without_dim, self._unit)
+            if name in ("skew", "kurt"):
+                result = u.Quantity(result_without_dim, u.dimensionless_unscaled)
+            else:
+                result = u.Quantity(result_without_dim, self._unit)
 
         elif name in ("any", "all", "prod"):
             raise TypeError(f"Cannot perform '{name}' with type '{self.dtype}'")

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -662,14 +662,8 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     ) -> UnitsExtensionArray | u.Quantity:
         # Borrowed from IntegerArray
 
-        to_proxy = ("min", "max", "sum", "mean", "std", "var")
-        to_nanops = ("median", "sem")
-        to_error = ("any", "all", "prod")
-
-        # TODO: Check the dimension of this
-        to_implement_yet = ("kurt", "skew")
-
-        if name in to_proxy:
+        # Implemented by astropy:
+        if name in ("min", "max", "sum", "mean", "std", "var"):
             q: u.Quantity = self.to_quantity()
             if name in ["std", "var"]:
                 kwargs = {"ddof": kwargs.pop("ddof", 1)}
@@ -679,17 +673,28 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
                 q = q[~np.isnan(q)]
             result: u.Quantity = getattr(q, name)(**kwargs)
 
-        elif name in to_nanops:
+        # Not implemented by astropy, but should be migrated to the top block of code when they do:
+        elif name == 'skew':
+            # Recycle methods from numpy and calculate Adjusted Fisher-Pearson Standardized Moment Coefficient:
+
+            mean = np.mean(self._value, **kwargs)
+            median = np.median(self._value, **kwargs)
+            standard_deviation = np.std(self._value, **kwargs)
+            result_without_dim = (3 * (mean - median)) / standard_deviation
+            result = u.Quantity(result_without_dim, u.dimensionless_unscaled)
+
+        elif name == "kurt":
+            pass
+
+        # This methods require a little ppost-processing for the nans:
+        elif name in ("median", "sem"):
             data = self._value
             method = getattr(nanops, "nan" + name)
             result_without_dim = method(data, skipna=skipna)
             result = u.Quantity(result_without_dim, self._unit)
 
-        elif name in to_error:
+        elif name in ("any", "all", "prod"):
             raise TypeError(f"Cannot perform '{name}' with type '{self.dtype}'")
-
-        elif name in to_implement_yet:
-            raise NotImplementedError
 
         else:
             raise ValueError(f"Invalid reduce operation: '{name}'")

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -379,13 +379,17 @@ class TestReshaping(base.BaseReshapingTests):
 class TestReduce(base.BaseReduceTests):
     def _supports_reduction(self, ser: pd.Series, op_name: str) -> bool:
         # List all supported numeric reductions
-        return op_name in {"sum", "max", "min", "mean", "std", "var", "median"}
+        return op_name in {"sum", "max", "min", "mean", "std", "var", "median", "sem", "skew", "kurt"}
 
     def _get_expected_reduction_dtype(self, arr, op_name: str, skipna: bool):
-        # Besides `var` all reductions retain the same unit so same dtype.
-        # However `var` returns a squared unit and the new expected dtype is calculated and returned
+        # Besides `var`, `skew`, and `kurt` all reductions retain the same unit so same dtype.
+        # `var` returns a squared unit and the new expected dtype is calculated and returned
         if op_name in {"var"}:
             return UnitsDtype(arr._unit**2)
+
+        # `skew` and `kurt` are dimensionless
+        if op_name in {"skew", "kurt"}:
+            return UnitsDtype(u.dimensionless_unscaled)
         return arr.dtype
 
     def check_reduce(self, ser: pd.Series, op_name: str, skipna: bool):
@@ -420,6 +424,12 @@ class TestReduce(base.BaseReduceTests):
 
     def test_var(self, data):
         assert np.allclose(pd.Series(data).var() / (u.m**2), 0.4555555555555555)
+
+    def test_skew(self, data):
+        assert np.allclose(pd.Series(data).skew(), -2.276596265448445)
+
+    def test_kurt(self, data):
+        assert np.allclose(pd.Series(data).kurt(), 4.765020820939921)
 
     def test_unsupported(self, data):
         for method in ["any", "all", "prod"]:


### PR DESCRIPTION
Closes #55 
**Context**

The `_reduce` method already used astropy's min/max/sum/mean/std/var to manage calculations with the units, and median/sem where delegated to pandas' nanops, but skew and kurt were left as NotImplementedError placeholders (marked with a TODO about checking dimensionality).

So, this PR wires skewness and kurtosis through pandas' own nanops implementations (cause I didn't want to reinvent the wheel). Astropy Quantity doesn't provide them natively, but I added a comment about changing this when it does.

**Task objectives**

- [x] Implement skew and kurt reductions for UnitsExtensionArray
- [x] Ensure the resulting dtype is dimensionless, since skewness/kurtosis are unit-independent statistics
- [x] Add test coverage for both reductions, including dtype and skip/no-skip behavior

**Implementation**

- In _reduce (src/pandas_units_extension/units.py), skew and kurt were merged into the same branch as median/sem, which recomputes the statistic on the raw _value array via pandas.core.nanops.nan<name> to manage the NaN values
- Unlike median/sem, which keep the array's original unit, skew/kurt results are wrapped as u.dimensionless_unscaled instead of self._unit, since these statistics are scale-invariant.
- I also added some more in-line comments, so the code is more readable here

**How did I tested this?**

- I extended TestReduce so ` _supports_reduction` reports sem, skew, and kurt as supported, and `_get_expected_reduction_dtype` returns UnitsDtype(u.dimensionless_unscaled) for skew/kurt (mirroring the existing special case for var, which returns a squared unit). I was not sure about implementing this or not, but I followed the existing pattern. Delete it if it isn't necessary!
- Also to follow the existing patterns of the librarí: I added explicit test_skew and test_kurt tests comparing pd.Series(data).skew() / .kurt() against known numeric values for the module's fixture data. **One suggestion for another issue:** Maybe this fixture should include NaNs, since that's the most common escenario when handling data.
- Ran uv run pytest tests/test_pandas_units_extension.py::TestReduce to confirm both the generic base-class tests and the new explicit ones pass.

I also wrote this small code snippet to test and verify by inspection:

```python

import numpy as np
import pandas as pd
import seaborn as sns
import matplotlib.pyplot as plt

# Example dataset
diamonds = sns.load_dataset("diamonds")
diamond_prices = diamonds["price"]

fig, axes = plt.subplots(1,1, figsize=(7, 5))
_ = axes.hist(diamond_prices, bins=50, density=True, alpha=0.7, color='steelblue', edgecolor='black')

# Positive Skew (Right Skew): Indicates that the right tail of the distribution is longer or fatter than the left.
# This means that the majority of data points are concentrated on the left side, with a few extreme values on the right.
print(f"skew: {pd.Series(diamond_prices, dtype="unit[m]").skew()}")

# A kurtosis greater than +2 suggests a too peaked distribution, while less than -2 indicates a too flat one.
print(f"kurt: {pd.Series(diamond_prices, dtype="unit[m]").kurt()}")
```
And this one as well:

```python
# When skewness and kurtosis are close to zero, it's considered a normal distribution (Hair et al., 2027)
vector = np.random.normal(size=500)

fig, axes = plt.subplots(1,1, figsize=(7, 5))
_ = axes.hist(vector, bins=50, density=True, alpha=0.7, color='steelblue', edgecolor='black')
print(f"skew: {pd.Series(vector, dtype="unit[m]").skew()}")
print(f"kurt: {pd.Series(vector, dtype="unit[m]").kurt()}")
```