### PR TITLE
Feat: add interpolate support to UnitsExtensionArray

### DIFF
--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -595,7 +595,7 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def interpolate(
         self,
         *,
-        method: "linear",
+        method: str = "linear",
         axis: int = 0,
         index=None,
         limit=None,

--- a/src/pandas_units_extension/units.py
+++ b/src/pandas_units_extension/units.py
@@ -592,6 +592,28 @@ class UnitsExtensionArray(ExtensionArray, ExtensionScalarOpsMixin):
     def isna(self):
         return np.isnan(self._value)
 
+    def interpolate(
+        self,
+        *,
+        method: "linear",
+        axis: int = 0,
+        index=None,
+        limit=None,
+        limit_direction="forward",
+        limit_area=None,
+        copy: bool = True,
+        **kwargs,
+    ) -> UnitsExtensionArray:
+        s = pd.Series(self._value, index=index)
+        interpolated = s.interpolate(
+            method=method,
+            limit=limit,
+            limit_direction=limit_direction,
+            limit_area=limit_area,
+            **kwargs,
+        )
+        return self._simple_new(interpolated.to_numpy(), self.dtype)
+
     @classmethod
     def _create_arithmetic_method(cls, op):
         op_name = f"__{op.__name__}__"

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -851,3 +851,11 @@ class TestArrayInterface:
     def test_disallowed_conversions(self, data, dtype):
         with pytest.raises(ValueError):
             np.array(data, dtype=dtype, copy=False)
+
+
+def test_interpolate():
+    # Verify that interpolation fills  missing values and retaining the unit dtype
+    s = pd.Series([1.0, 2.0, None, 4.0], dtype="unit[m]")
+    result = s.interpolate()
+    expected = pd.Series([1.0, 2.0, 3.0, 4.0], dtype="unit[m]")
+    pd.testing.assert_series_equal(result, expected)

--- a/tests/test_pandas_units_extension.py
+++ b/tests/test_pandas_units_extension.py
@@ -892,6 +892,8 @@ def test_interpolate():
     result = s.interpolate()
     expected = pd.Series([1.0, 2.0, 3.0, 4.0], dtype="unit[m]")
     pd.testing.assert_series_equal(result, expected)
+
+
 class TestValuesForJson:
     def test_simple_unit_strings(self, simple_data):
         result = simple_data._values_for_json()


### PR DESCRIPTION
### Changes
- Implemented `interpolate()` method in `UnitsExtensionArray` while preserving unit dtypes.
- Added corresponding unit tests in `tests/test_pandas_units_extension.py`.
